### PR TITLE
Indicate error words/resources in UI

### DIFF
--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -1,11 +1,13 @@
 import moment from "moment";
 import { motion } from "framer-motion";
+import { WordScrapeError } from "../types/types";
 
 interface Props {
   downloadUrl: string;
+  errors: WordScrapeError[];
 }
 
-export default function Download({ downloadUrl }: Props) {
+export default function Download({ downloadUrl, errors }: Props) {
   return (
     <motion.div
       variants={{
@@ -25,15 +27,29 @@ export default function Download({ downloadUrl }: Props) {
       <p className="text-5xl secondary-text my-2 font-bold">
         Your csv is ready to be downloaded.
       </p>
-      <p className="text-lg secondary-text mt-2 mb-16">
+      <p className="text-lg secondary-text mt-2 mb-4">
         For instructions on how to import the files into Anki, please see{" "}
         <a className="underline" href="https://github.com/TBarmak/anki-lang">
           this article
         </a>
         .
       </p>
+      {errors.length > 0 && (
+        <div>
+          <p className="accent-text">Error fetching data for:</p>
+          <div className="h-16 overflow-scroll">
+            {errors.map((error) => {
+              return (
+                <p className="accent-text">
+                  {error.word}: {error.errors.join(", ")}
+                </p>
+              );
+            })}
+          </div>
+        </div>
+      )}
       <a
-        className="my-16"
+        className="my-16 mt-24"
         href={downloadUrl}
         download={`anki-lang-${moment().format("YYYYMMDDHHmmss")}.zip`}
       >

--- a/src/components/forms/utils/__tests__/getFlashcardData.spec.ts
+++ b/src/components/forms/utils/__tests__/getFlashcardData.spec.ts
@@ -81,6 +81,7 @@ describe("getFlashcardData.ts", () => {
           expect(data[0].inputWord).toEqual(abacaxiWordReferenceInput.words);
           expect(data[0].scrapedWordData.length).toEqual(0);
           expect(data[0].urls).toEqual([]);
+          expect(data[0].errors).toEqual(["Word Reference"]);
         });
       });
     });
@@ -129,6 +130,7 @@ describe("getFlashcardData.ts", () => {
             abacaxiMichaelisResponse.scrapedWordData.length
           );
           expect(data[0].urls).toEqual([abacaxiMichaelisResponse.url]);
+          expect(data[0].errors).toEqual(["Word Reference"])
         });
       });
     });

--- a/src/components/forms/utils/getFlashcardData.ts
+++ b/src/components/forms/utils/getFlashcardData.ts
@@ -38,7 +38,12 @@ export function getFlashcardData(
                 res(data);
               })
               .catch((err) => {
-                res({ inputWord: word, scrapedWordData: [], url: "" });
+                res({
+                  inputWord: word,
+                  scrapedWordData: [],
+                  url: "",
+                  error: resource.name,
+                });
               });
           });
         });
@@ -46,7 +51,7 @@ export function getFlashcardData(
       Promise.all(resourcePromises).then((responses: ScrapedResponse[]) => {
         const combinedScrapedData: ScrapedItem[] = ([] as ScrapedItem[]).concat(
           ...responses
-            .filter((response) => response.scrapedWordData)
+            .filter((response) => response.scrapedWordData.length)
             .map((response) => response.scrapedWordData)
         );
         res({
@@ -55,6 +60,9 @@ export function getFlashcardData(
           urls: responses
             .filter((res) => res.url)
             .map((res) => res.url as string),
+          errors: responses
+            .filter((res) => res.error)
+            .map((res) => res.error as string),
         });
       });
     });

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,17 +1,30 @@
 import { useState } from "react";
 import Loading from "../components/Loading";
-import { CombinedScrapedResponse, ScrapedResponse } from "../types/types";
+import {
+  CombinedScrapedResponse,
+  ScrapedResponse,
+  WordScrapeError,
+} from "../types/types";
 import ResourceForm from "../components/forms/ResourceForm";
 import CardFormatForm from "../components/forms/CardFormatForm";
 import Download from "../components/Download";
 
 export default function Main() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [scrapedData, setScrapedData] = useState<
-    ScrapedResponse[] | CombinedScrapedResponse[]
-  >([]);
+  const [scrapedData, setScrapedData] = useState<CombinedScrapedResponse[]>([]);
   const [downloadUrl, setDownloadUrl] = useState<string>("");
   const [exportFields, setExportFields] = useState<string[]>([]);
+
+  function getErrors(): WordScrapeError[] {
+    return scrapedData
+      .filter((scrapedWordData) => scrapedWordData.errors?.length)
+      .map((scrapedWordData) => {
+        return {
+          word: scrapedWordData.inputWord,
+          errors: scrapedWordData.errors ?? [],
+        };
+      });
+  }
 
   if (isLoading) {
     return (
@@ -24,7 +37,7 @@ export default function Main() {
   if (downloadUrl) {
     return (
       <div className="w-full h-screen route-component">
-        <Download downloadUrl={downloadUrl} />
+        <Download downloadUrl={downloadUrl} errors={getErrors()} />
       </div>
     );
   }

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -27,16 +27,23 @@ export interface FormErrors {
   languageResources?: string;
 }
 
+export interface WordScrapeError {
+  word: string;
+  errors: string[];
+}
+
 export interface ScrapedResponse {
   inputWord: string;
   scrapedWordData: ScrapedItem[];
   url?: string;
+  error?: string;
 }
 
 export interface CombinedScrapedResponse {
   inputWord: string;
   scrapedWordData: ScrapedItem[];
   urls?: string[];
+  errors?: string[];
 }
 
 export interface ScrapedItem {


### PR DESCRIPTION
When resources fail to scrape information for a word, it will now be indicated on the download page. This way the user knows to expect those flashcards to be empty when importing into Anki.