### PR TITLE
[Feat] Host at anki.taylorbarmak.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/anki.taylorbarmak.com
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/anki.taylorbarmak.com
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Anki Lingo
 **Anki Lingo** is a React and Flask application for generating Anki flashcards for learning languages. It scrapes popular language learning sites like Word Reference, SpanishDict, and Forvo to fetch translations, example sentences, and much more!
 
+It is currently hosted at https://anki.taylorbarmak.com.
+
 <img src="./docs/photos/landing.png" alt="landing" width="800"/>
 
 The user simply enters words in the target language, and selects resources for that language to scrape from.

--- a/deployment/nginx.host.conf
+++ b/deployment/nginx.host.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name anki.taylorbarmak.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080; # Forward to the client container
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name anki.taylorbarmak.com;
+
+    ssl_certificate /etc/letsencrypt/live/anki.taylorbarmak.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/anki.taylorbarmak.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,4 @@ services:
       dockerfile: Dockerfile.client
     image: anki-lingo-client
     ports:
-      # Set to "3000:80" when running locally, "80:80" for hosting with EC2
-      - "80:80"
+      - "8080:80"

--- a/docs/LinkingEc2ToDomain.md
+++ b/docs/LinkingEc2ToDomain.md
@@ -1,0 +1,22 @@
+# Linking EC2 to Domain
+The `deploy.yml` Github workflow currently deploys the code to an EC2 instance, and the website is accessible via `http://<ip address>`. Below will detail the steps for making it accessible via `anki.taylorbarmak.com`.
+
+1. In the domain registrar, create a new A record.
+    Name/Host: anki
+    Value/Points to: the EC2 instance's public IP address.
+    TTL: Leave the default value (e.g., 3600 seconds).
+2. Ensure that the EC2's security groups have inbound rules allowing traffic on ports 443 and 80.
+3. Install `nginx` on the EC2 instance (host) with `sudo yum install nginx -y`.
+4. Create a new Nginx configuration for `anki.taylorbarmak.com`, and place it in `/etc/nginx/conf.d/anki.conf` in the host EC2. This file is currently stored in this repo in `deployment/nginx.host.conf`.
+5. Run `sudo nginx -t` and `sudo systemctl restart nginx`.
+6. Go to `http://anki.taylorbarmak.com` to confirm that it is working properly.
+
+## Securing with HTTPS
+I found [this Medium article](https://faun.pub/enable-https-on-ec2-instance-without-elastic-load-balancer-f69cd57a8f3a) very helpful.
+1. In the EC2 instance, run `sudo yum install -y certbot`.
+2. Stop nginx with `sudo systemctl stop nginx`.
+3. Generate an SSL certificate with `sudo certbot certonly --standalone -d anki.taylorbarmak.com`.
+4. Update the nginx conf to listen on 443 and point the `ssl_certificate` and `ssl_certificate_key` to the correct paths in `/etc/letsencrypt/live/` (This is already done in `deployment/nginx.host.conf`)
+5. Run `sudo nginx -t` and `sudo systemctl restart nginx`.
+6. Go to `https://anki.taylorbarmak.com` and confirm it doesn't say "Not Secure" anymore.
+7. Automate the certificate renewal process in the EC2 by running `sudo sh -c 'echo "0 12 * * * /usr/bin/certbot renew --quiet" >> /etc/crontab'`.


### PR DESCRIPTION
## Description
Adds an nginx config for the host EC2 and updates the docker-compose set up to host the application at `anki.taylorbarmak.com`. It also adds HTTPS support. Previously, the application was accessible via the EC2's IP address on port 80.

This change configures Nginx as a reverse proxy to forward requests to the application running on port 8080. The docker-compose port mapping was updated to serve the application on port 8080.

Followed [this medium article](https://faun.pub/enable-https-on-ec2-instance-without-elastic-load-balancer-f69cd57a8f3a) for guidance on configuring HTTPS.
