### PR TITLE
Forvo(fix): Fix 403s on local

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,5 +28,6 @@ jobs:
         ssh -o StrictHostKeyChecking=no ec2-user@54.152.37.238 << EOF
           cd /home/ec2-user/app
           docker-compose down
+          docker system prune -f --volumes
           docker-compose up -d --build
         EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/forvo-403
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/forvo-403
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Resources have health checks to validate that the sites are being scraped as exp
 After clicking the "Generate" button, the resources will be scraped.
 
 After the information is scraped, the user can design the flashcards by selecting which fields to include, and which side to put them on. For example, I prefer to put example sentences in the target language on a separate side.
+
 <img src="./docs/photos/design_flashcards.png" alt="design flashcards" width="800"/>
 <img src="./docs/photos/csv_download.png" alt="csv download" width="800"/>
 
@@ -33,13 +34,17 @@ Expand the zip file to get the `anki.csv` and the `audio_files`, if applicable.
 
 ### Importing CSV into Anki
 In Anki, click "Import File"
+
 <img src="./docs/photos/anki_import.png" alt="anki import" width="800"/>
+
 and select the `anki.csv` file from the expanded zip.
 
 Make sure the "Field separator" is "Pipe", and that "Allow HTML in fields" is toggled on.
+
 <img src="./docs/photos/anki_file_options.png" alt="anki file options" width="800"/>
 
 Update the "Import options" and "Field mapping" according to how you designed your flashcards.
+
 <img src="./docs/photos/anki_field_mapping.png" alt="anki field mapping" width="800"/>
 
 Finally, click the "Import" button.

--- a/api/api.py
+++ b/api/api.py
@@ -54,7 +54,7 @@ LANGUAGE_RESOURCES = [
         "healthRoute": "api/forvo/português/abacaxi",
         "args": ["targetLang", "word"],
         "outputs": ["audioFilenames"],
-        "supportedLanguages": ["français", "português", "español", "english"]
+        "supportedLanguages": ["français", "português", "español", "english", "italiano"]
     },
     {
         "name": "Semanticar BR",

--- a/api/scrapers/forvo.py
+++ b/api/scrapers/forvo.py
@@ -64,18 +64,14 @@ def scrape_forvo(word: str, language: str):
     url = create_url(word, lang_abbv)
     url_request = urllib.request.Request(
         url, headers=headers)
-    try:
-        with urllib.request.urlopen(url_request) as response:
-            print(response.getcode())
-            content = response.read()
-            print(content)
-            soup = BeautifulSoup(content, "html.parser")
-            table = get_table(soup, lang_abbv)
-            pronunciation_url = get_top_pronunciation_url(table)
-            output_filename = download_audio(pronunciation_url, word, lang_abbv)
-            return [{"audioFilenames": [output_filename]}], url, response.getcode()
-    except urllib.error.HTTPError as e:
-        return [], url, e.code
-    except urllib.error.URLError as e:
-        return [], url, 500
+    response = urllib.request.urlopen(url_request)
+    if response.getcode() == 200:
+        content = response.read()
+        soup = BeautifulSoup(content, "html.parser")
+        table = get_table(soup, lang_abbv)
+        pronunciation_url = get_top_pronunciation_url(table)
+        output_filename = download_audio(pronunciation_url, word, lang_abbv)
+        return [{"audioFilenames": [output_filename]}], url, response.getcode()
+    else:
+        return [], url, response.getcode()
     

--- a/api/scrapers/forvo.py
+++ b/api/scrapers/forvo.py
@@ -64,14 +64,16 @@ def scrape_forvo(word: str, language: str):
     url = create_url(word, lang_abbv)
     url_request = urllib.request.Request(
         url, headers=headers)
-    response = urllib.request.urlopen(url_request)
-    if response.getcode() == 200:
+    try:
+        response = urllib.request.urlopen(url_request)
         content = response.read()
         soup = BeautifulSoup(content, "html.parser")
         table = get_table(soup, lang_abbv)
         pronunciation_url = get_top_pronunciation_url(table)
         output_filename = download_audio(pronunciation_url, word, lang_abbv)
         return [{"audioFilenames": [output_filename]}], url, response.getcode()
-    else:
-        return [], url, response.getcode()
+    except urllib.error.HTTPError as e:
+        return [], url, e.code
+    except urllib.error.URLError as e:
+        return [], url, 500
     

--- a/api/scrapers/forvo.py
+++ b/api/scrapers/forvo.py
@@ -9,7 +9,8 @@ LANGUAGE_TO_ABBV = {
     "english": "en_usa",
     "español": "es_es",
     "français": "fr",
-    "português": "pt_br"
+    "português": "pt_br",
+    "italiano": "it"
 }
 
 headers = {
@@ -50,7 +51,7 @@ def get_top_pronunciation_url(table):
 
 def download_audio(url: str, word: str, lang_abbv: str):
     url_request = urllib.request.Request(
-        url, headers={"User-Agent": "Mozilla/5.0"})
+        url, headers=headers)
     response = urllib.request.urlopen(url_request)
     output_filename = f"pronunciation_{lang_abbv}_{'_'.join(word.split())}.ogg"
     with open("audio_files/" + output_filename, "b+w") as fh:
@@ -61,12 +62,20 @@ def download_audio(url: str, word: str, lang_abbv: str):
 def scrape_forvo(word: str, language: str):
     lang_abbv = LANGUAGE_TO_ABBV[language.lower()]
     url = create_url(word, lang_abbv)
-    response = requests.get(url, headers=headers)
-    if response.ok:
-        soup = BeautifulSoup(response.content, "html.parser")
-        table = get_table(soup, lang_abbv)
-        pronunciation_url = get_top_pronunciation_url(table)
-        output_filename = download_audio(pronunciation_url, word, lang_abbv)
-        return [{"audioFilenames": [output_filename]}], url, response.status_code
-    else:
-        return [], url, response.status_code
+    url_request = urllib.request.Request(
+        url, headers=headers)
+    try:
+        with urllib.request.urlopen(url_request) as response:
+            print(response.getcode())
+            content = response.read()
+            print(content)
+            soup = BeautifulSoup(content, "html.parser")
+            table = get_table(soup, lang_abbv)
+            pronunciation_url = get_top_pronunciation_url(table)
+            output_filename = download_audio(pronunciation_url, word, lang_abbv)
+            return [{"audioFilenames": [output_filename]}], url, response.getcode()
+    except urllib.error.HTTPError as e:
+        return [], url, e.code
+    except urllib.error.URLError as e:
+        return [], url, 500
+    

--- a/api/scrapers/tests/test_forvo.py
+++ b/api/scrapers/tests/test_forvo.py
@@ -1,7 +1,7 @@
 from api.scrapers.forvo import create_url, scrape_forvo
 from unittest.mock import patch, mock_open, MagicMock
 from api.scrapers.tests.utils.get_mock_response import get_mock_response
-
+from urllib.error import HTTPError
 
 def get_mock_response_filename(word, lang_abbv):
     return f"forvo_{word}_{lang_abbv}.html"
@@ -61,9 +61,13 @@ class TestForvo:
         # Arrange
         word = "avoir"
         language = "français"
-        mock_urlopen.return_value.read.return_value = "".encode(
-            "UTF-8")
-        mock_urlopen.return_value.getcode.return_value = 403
+        mock_urlopen.side_effect = HTTPError(
+            url="https://forvo.com",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,
+            fp=None
+        )
         # Act
         audio_filenames, url, status_code = scrape_forvo(word, language)
         # Assert

--- a/api/scrapers/tests/test_forvo.py
+++ b/api/scrapers/tests/test_forvo.py
@@ -53,7 +53,7 @@ class TestForvo:
             "audio_files/pronunciation_fr_avoir.ogg", "b+w")
         assert audio_filenames == [
             {"audioFilenames": ["pronunciation_fr_avoir.ogg"]}]
-        assert url == "https://forvo.com/word/avoir/#fr"
+        assert url == create_url(word, "fr") 
         assert status_code == 200
 
     @patch("urllib.request.urlopen")


### PR DESCRIPTION
## Description
Forvo was giving 403s when running locally. This PR updates the Forvo scraper to use `urllib.request` instead of `requests`, which fixes the issue when running locally.

## Summary of changes
- Use `urllib.request` instead of `requests` for Forvo scraper
- Adds support for Italian with Forvo
- Call `docker system prune -f --volumes` before deploying to free up space
- Fixes some formatting issues in README.md

During one of the deployments, I got an error `failed to solve: failed to register layer: write /usr/local/bin/node: no space left on device`. I resolved this by calling `docker system prune -f --volumes` before deploying. Since this EC2 instance is only used for hosting this app, this should be fine.

Unfortunately, it looks like it's blocked when deployed to the EC2. I think Forvo is blocking AWS IP addresses.