### PR TITLE
[Refactor] Add React Redux and break ResourceForm into components

### DIFF
--- a/api/scrapers/spanishdict.py
+++ b/api/scrapers/spanishdict.py
@@ -32,10 +32,10 @@ def parse_pos_block(pos_block, target_lang_abbv):
                 targetExampleSentences (list): list of string example sentences in the target language
                 nativeExampleSentences (list): list of string example sentences in the native language 
     '''
-    pos = pos_block.findChildren(recursive=False)[0].find_all(string=True)[-1]
+    pos = pos_block.find_all(recursive=False)[0].find_all(string=True)[-1]
 
-    translation_blocks = pos_block.findChildren(
-        recursive=False)[1].findChildren(recursive=False)
+    translation_blocks = pos_block.find_all(
+        recursive=False)[1].find_all(recursive=False)
     parsed_translation_blocks = [parse_translation_block(
         block, target_lang_abbv) for block in translation_blocks]
     for parsed_translation_block in parsed_translation_blocks:
@@ -63,10 +63,10 @@ def parse_translation_block(translation_block, target_lang_abbv):
                 nativeExampleSentences (list): list of string example sentences in the native language 
     '''
     parenthesized_translations = "".join(
-        [item.text for item in translation_block.findChildren(recursive=False)[0].findAll("a")])
+        [item.text for item in translation_block.find_all(recursive=False)[0].find_all("a")])
 
-    translation_subblocks = translation_block.findChildren(
-        recursive=False)[1].findChildren(recursive=False)
+    translation_subblocks = translation_block.find_all(
+        recursive=False)[1].find_all(recursive=False)
     parsed_translation_subblocks = [parse_translation_subblock(
         subblock, target_lang_abbv) for subblock in translation_subblocks]
     parsed_translation_block = {}
@@ -102,13 +102,13 @@ def parse_translation_subblock(translation_subblock, target_lang_abbv):
     native_lang_abbv = "en" if target_lang_abbv == "es" else "en"
     translation = "no direct translation"
     try:
-        translation = translation_subblock.findChildren(
+        translation = translation_subblock.find_all(
             recursive=False)[0].find("a").contents[0]
     except:
         pass
-    target_example_sentences = [sentence.contents[0] for sentence in translation_subblock.findAll(
+    target_example_sentences = [sentence.contents[0] for sentence in translation_subblock.find_all(
         "span", {"lang": target_lang_abbv})]
-    native_example_sentences = [sentence.contents[0] for sentence in translation_subblock.findAll(
+    native_example_sentences = [sentence.contents[0] for sentence in translation_subblock.find_all(
         "span", {"lang": native_lang_abbv})]
     parsed_translation_subblock = {
         "translations": [translation], 
@@ -151,10 +151,10 @@ def scrape_spanishdict(word, target_lang):
             "div", {"id": f"dictionary-neodict-{target_lang_abbv}"})
 
         # Extract the word from SpanishDict in case it differs from the word submitted (ie due to a typo)
-        spanishdict_word = meanings_container.findChildren(
-            recursive=False)[0].findChildren(recursive=False)[0].find("span").contents[0]
-        pos_blocks = meanings_container.findChildren(
-            recursive=False)[0].findChildren(recursive=False)[0].findChildren(recursive=False)[1:]
+        spanishdict_word = meanings_container.find_all(
+            recursive=False)[0].find_all(recursive=False)[0].find("span").contents[0]
+        pos_blocks = meanings_container.find_all(
+            recursive=False)[0].find_all(recursive=False)[0].find_all(recursive=False)[1:]
         parsed_pos_blocks = [parse_pos_block(
             block, target_lang_abbv) for block in pos_blocks]
         translations_list = []

--- a/api/scrapers/word_reference.py
+++ b/api/scrapers/word_reference.py
@@ -39,7 +39,7 @@ def parse_first_table(table):
                 entry["pos"] = row.find_all(
                     "td", {"class": "FrWrd"})[0].em.text
                 entry["word"] = "".join(row.find_all("td", {"class": "FrWrd"})[
-                                        0].strong.findAll(string=True))
+                                        0].strong.find_all(string=True))
                 entry["definition"] = row.find_all("td")[1].text.strip()
                 entry["translations"] = []
                 entry["nativeExampleSentences"] = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "anki-lingo",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.6.1",
         "framer-motion": "^12.6.5",
         "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
         "react-loader-spinner": "^6.1.6",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^6.30.0"
       },
       "devDependencies": {
@@ -1065,6 +1067,30 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.6.1.tgz",
+      "integrity": "sha512-SSlIqZNYhqm/oMkXbtofwZSt9lrncblzo6YcZ9zoX+zLngRBrCOjK4lNLdkNucJF58RHOWrD9txT3bT3piH7Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1655,13 +1681,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.20",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1682,6 +1708,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.29.1",
@@ -2512,7 +2544,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3424,6 +3456,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -4386,6 +4428,29 @@
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "6.30.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
@@ -4440,11 +4505,32 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -5172,6 +5258,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
     "test-api": "api/env/bin/pytest"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.6.1",
     "framer-motion": "^12.6.5",
     "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
     "react-loader-spinner": "^6.1.6",
+    "react-redux": "^9.2.0",
     "react-router-dom": "^6.30.0"
   },
   "devDependencies": {

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -29,7 +29,7 @@ export default function Download({ downloadUrl, errors }: Props) {
       </p>
       <p className="text-lg secondary-text mt-2 mb-4">
         For instructions on how to import the files into Anki, please see{" "}
-        <a className="underline" href="https://github.com/TBarmak/anki-lingo">
+        <a className="underline" href="https://github.com/TBarmak/anki-lingo/blob/main/README.md">
           this article
         </a>
         .

--- a/src/components/forms/CardFormatForm.tsx
+++ b/src/components/forms/CardFormatForm.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
-import {
+import type {
   CardFormat,
   CardSide,
-  CombinedScrapedResponse,
 } from "../../types/types";
 import {
   MdOutlineRemoveCircle,
@@ -12,19 +11,18 @@ import {
   MdRemoveCircle,
 } from "react-icons/md";
 import { AnimatePresence, motion } from "framer-motion";
+import { useDispatch, useSelector } from "react-redux";
+import { setIsLoading } from "../../store/slice";
+import type { RootState } from "../../store";
 
 type Props = {
-  scrapedData: CombinedScrapedResponse[];
   exportFields: string[];
   setDownloadUrl: React.Dispatch<React.SetStateAction<string>>;
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function CardFormatForm({
-  scrapedData,
   exportFields,
   setDownloadUrl,
-  setIsLoading,
 }: Props) {
   const [fieldMapping, setFieldMapping] = useState<{ [key: string]: string }>();
   const [cardFormat, setCardFormat] = useState<CardFormat>({
@@ -36,7 +34,12 @@ export default function CardFormatForm({
   const MIN_SIDES = 2;
   const MAX_SIDES = 5;
 
+  const scrapedData = useSelector((state: RootState) => state.root.scrapedData);
+
+  const dispatch = useDispatch();
+
   useEffect(() => {
+    console.log("export fields in CardFormatForm", exportFields);
     fetch("api/field-mapping")
       .then((res) => res.json())
       .then((data) => setFieldMapping(data));
@@ -88,7 +91,7 @@ export default function CardFormatForm({
       .then((blob) => {
         const url = window.URL.createObjectURL(new Blob([blob]));
         setDownloadUrl(url);
-        setIsLoading(false);
+        dispatch(setIsLoading(false));
       });
   }
 

--- a/src/components/forms/CardFormatForm.tsx
+++ b/src/components/forms/CardFormatForm.tsx
@@ -39,7 +39,6 @@ export default function CardFormatForm({
   const dispatch = useDispatch();
 
   useEffect(() => {
-    console.log("export fields in CardFormatForm", exportFields);
     fetch("api/field-mapping")
       .then((res) => res.json())
       .then((data) => setFieldMapping(data));

--- a/src/components/forms/ResourceForm.tsx
+++ b/src/components/forms/ResourceForm.tsx
@@ -1,28 +1,15 @@
-import { useEffect, useState } from "react";
-import {
-  CombinedScrapedResponse,
-  InputFields,
-  LanguageResource,
-  ScrapedResponse,
-} from "../../types/types";
-import { AnimatePresence } from "framer-motion";
+import { type ReactNode, useEffect, useState } from "react";
+import type { InputFields, LanguageResource } from "../../types/types";
+import { AnimatePresence, motion } from "framer-motion";
 import LanguageSelector from "./resource-form/LanguageSelector";
 import WordTextArea from "./resource-form/WordTextArea";
 import ResourceSelector from "./resource-form/ResourceSelector";
 
 type Props = {
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
-  setScrapedData: React.Dispatch<
-    React.SetStateAction<(ScrapedResponse | CombinedScrapedResponse)[]>
-  >;
   setExportFields: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
-export default function ResourceForm({
-  setIsLoading,
-  setScrapedData,
-  setExportFields,
-}: Props) {
+export default function ResourceForm({ setExportFields }: Props) {
   const [languageResources, setLanguageResources] = useState<
     LanguageResource[]
   >([]);
@@ -55,32 +42,69 @@ export default function ResourceForm({
   }, [inputFields.targetLanguage]);
 
   useEffect(() => {
-    const exportFields = ([] as string[]).concat(
-      ...languageResources
-        .filter((resource: LanguageResource) => resource.isSelected)
-        .map((resource: LanguageResource) => resource.outputs)
-    );
-    setExportFields([...new Set(exportFields)]);
+    if (languageResources.length) {
+      const exportFields = ([] as string[]).concat(
+        ...languageResources
+          .filter((resource: LanguageResource) => resource.isSelected)
+          .map((resource: LanguageResource) => resource.outputs)
+      );
+      setExportFields([...new Set(exportFields)]);
+    }
   }, [languageResources]);
 
   return (
     <AnimatePresence mode="wait">
-      {!inputFields.targetLanguage ||
-      !inputFields.nativeLanguage ||
-      inputFields.targetLanguage === inputFields.nativeLanguage ? (
-        <LanguageSelector setInputFields={setInputFields} />
-      ) : !inputFields.words ? (
-        <WordTextArea setInputFields={setInputFields} />
-      ) : (
-        <ResourceSelector
-          inputFields={inputFields}
-          setIsLoading={setIsLoading}
-          setScrapedData={setScrapedData}
-          setInputFields={setInputFields}
-          setLanguageResources={setLanguageResources}
-          languageResources={languageResources}
-        />
-      )}
+      {((): ReactNode => {
+        if (
+          !inputFields.targetLanguage ||
+          !inputFields.nativeLanguage ||
+          inputFields.targetLanguage === inputFields.nativeLanguage
+        ) {
+          return (
+            <motion.div
+              key="language-selection"
+              className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{
+                opacity: 0,
+                transition: { ease: "easeInOut", duration: 0.75 },
+              }}
+            >
+              <LanguageSelector setInputFields={setInputFields} />
+            </motion.div>
+          );
+        } else if (!inputFields.words) {
+          return (
+            <motion.div
+              key="word-entry"
+              className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0, transition: { duration: 0.75 } }}
+            >
+              <WordTextArea setInputFields={setInputFields} />
+            </motion.div>
+          );
+        } else {
+          return (
+            <motion.div
+              key="resources-selection"
+              className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0, transition: { duration: 0.75 } }}
+            >
+              <ResourceSelector
+                inputFields={inputFields}
+                setInputFields={setInputFields}
+                setLanguageResources={setLanguageResources}
+                languageResources={languageResources}
+              />
+            </motion.div>
+          );
+        }
+      })()}
     </AnimatePresence>
   );
 }

--- a/src/components/forms/ResourceForm.tsx
+++ b/src/components/forms/ResourceForm.tsx
@@ -5,11 +5,10 @@ import {
   LanguageResource,
   ScrapedResponse,
 } from "../../types/types";
-import FormError from "./FormError";
-import { getFlashcardData } from "./utils/getFlashcardData";
-import { MdCheckBox, MdCheckBoxOutlineBlank } from "react-icons/md";
-import { AnimatePresence, motion } from "framer-motion";
-import { IoChevronBackOutline } from "react-icons/io5";
+import { AnimatePresence } from "framer-motion";
+import LanguageSelector from "./resource-form/LanguageSelector";
+import WordTextArea from "./resource-form/WordTextArea";
+import ResourceSelector from "./resource-form/ResourceSelector";
 
 type Props = {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
@@ -24,10 +23,6 @@ export default function ResourceForm({
   setScrapedData,
   setExportFields,
 }: Props) {
-  const [supportedLanguages, setSupportedLanguages] = useState<string[]>([]);
-  const [words, setWords] = useState<string>("");
-  const [targetLanguage, setTargetLanguage] = useState<string>("");
-  const [nativeLanguage, setNativeLanguage] = useState<string>("");
   const [languageResources, setLanguageResources] = useState<
     LanguageResource[]
   >([]);
@@ -36,15 +31,9 @@ export default function ResourceForm({
   );
 
   useEffect(() => {
-    fetch("api/supported-languages")
-      .then((res) => res.json())
-      .then((data) => setSupportedLanguages(data.languages));
-  }, []);
-
-  useEffect(() => {
     setLanguageResources([]);
-    if (targetLanguage) {
-      fetch(`api/resources/${targetLanguage}`)
+    if (inputFields.targetLanguage) {
+      fetch(`api/resources/${inputFields.targetLanguage}`)
         .then((res) => res.json())
         .then(async (data) => {
           const healthPromises: Promise<boolean>[] = data.resources.map(
@@ -63,7 +52,7 @@ export default function ResourceForm({
     } else {
       setLanguageResources([]);
     }
-  }, [targetLanguage]);
+  }, [inputFields.targetLanguage]);
 
   useEffect(() => {
     const exportFields = ([] as string[]).concat(
@@ -74,356 +63,23 @@ export default function ResourceForm({
     setExportFields([...new Set(exportFields)]);
   }, [languageResources]);
 
-  function handleResourceCheckboxChange(
-    e: React.ChangeEvent<HTMLInputElement>
-  ) {
-    const newCheckboxField = languageResources.map((field) => {
-      if (field.name === e.target.name) {
-        field.isSelected = !field.isSelected;
-      }
-      return field;
-    });
-    setLanguageResources(newCheckboxField);
-  }
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setIsLoading(true);
-    getFlashcardData({ ...inputFields, languageResources }).then((res) => {
-      setScrapedData(res);
-      setIsLoading(false);
-    });
-  }
-
   return (
     <AnimatePresence mode="wait">
       {!inputFields.targetLanguage ||
       !inputFields.nativeLanguage ||
       inputFields.targetLanguage === inputFields.nativeLanguage ? (
-        <motion.div
-          key="language-selection"
-          className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{
-            opacity: 0,
-            transition: { ease: "easeInOut", duration: 0.75 },
-          }}
-        >
-          <div>
-            <motion.p
-              className="text-3xl font-bold text-center my-4"
-              initial={{ opacity: 0, y: -100 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, delay: 0.5 }}
-            >
-              Enter your target language and native language
-            </motion.p>
-            <motion.div
-              className="mb-4 flex flex-col w-full"
-              initial={{ opacity: 0, x: 100 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.75, delay: 0.75 }}
-            >
-              <p className="font-bold secondary-text">Target language</p>
-              <select
-                name="targetLanguage"
-                className="secondary-text p-2 pr-8 rounded-lg input text-lg"
-                value={targetLanguage}
-                onChange={(e) => setTargetLanguage(e.target.value)}
-              >
-                <option value="">Select target language</option>
-                {supportedLanguages.map((language, index) => (
-                  <option key={index} value={language}>
-                    {language}
-                  </option>
-                ))}
-              </select>
-              {targetLanguage && targetLanguage === nativeLanguage && (
-                <FormError
-                  message={
-                    "Target language must be different from native language"
-                  }
-                />
-              )}
-            </motion.div>
-            <motion.div
-              className="mb-4 flex flex-col w-full"
-              initial={{ opacity: 0, x: 100 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.75, delay: 1 }}
-            >
-              <p className="font-bold secondary-text">Native language</p>
-              <select
-                name="nativeLanguage"
-                className="secondary-text p-2 pr-8 rounded-lg input text-lg"
-                value={nativeLanguage}
-                onChange={(e) => setNativeLanguage(e.target.value)}
-              >
-                <option value="">Select native language</option>
-                {supportedLanguages.map((language, index) => (
-                  <option key={index} value={language}>
-                    {language}
-                  </option>
-                ))}
-              </select>
-              {nativeLanguage && nativeLanguage === targetLanguage && (
-                <FormError
-                  message={
-                    "Native language must be different from target language"
-                  }
-                />
-              )}
-            </motion.div>
-          </div>
-          <div className="flex flex-row w-full justify-center my-8">
-            <motion.div
-              initial={{ opacity: 0, y: 100 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, delay: 1.25 }}
-            >
-              <motion.button
-                className="button"
-                whileHover={
-                  !nativeLanguage ||
-                  !targetLanguage ||
-                  nativeLanguage === targetLanguage
-                    ? undefined
-                    : { scale: 1.05 }
-                }
-                disabled={
-                  !nativeLanguage ||
-                  !targetLanguage ||
-                  nativeLanguage === targetLanguage
-                }
-                onClick={() => {
-                  setInputFields({
-                    nativeLanguage: nativeLanguage,
-                    targetLanguage: targetLanguage,
-                  } as InputFields);
-                }}
-              >
-                Continue
-              </motion.button>
-            </motion.div>
-          </div>
-        </motion.div>
+        <LanguageSelector setInputFields={setInputFields} />
       ) : !inputFields.words ? (
-        <motion.div
-          key="word-entry"
-          className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0, transition: { duration: 0.75 } }}
-        >
-          <div>
-            <motion.button
-              initial={{ opacity: 0, y: -100 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, delay: 1.25 }}
-              onClick={() => setInputFields({} as InputFields)}
-              className="text-lg flex items-center"
-            >
-              <div className="group hover:cursor-pointer flex items-center">
-                <div className="flex flex-col justify-center items-start">
-                  <IoChevronBackOutline color="#162e50" />
-                  <div className="h-0.5" />
-                </div>
-                <div className="flex flex-col justify-center items-start">
-                  <p className="mx-1 secondary-text">Go back</p>
-                  <div
-                    className={
-                      "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
-                    }
-                  />
-                </div>
-              </div>
-            </motion.button>
-            <motion.p
-              className="text-3xl font-bold text-center my-4"
-              initial={{ opacity: 0, y: -100 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, delay: 0.5 }}
-            >
-              Enter words and/or phrases in the target language
-            </motion.p>
-            <motion.div
-              className="mb-4 flex flex-col w-full"
-              initial={{ opacity: 0, y: 100 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, delay: 0.75 }}
-            >
-              <p className="font-bold secondary-text">Words/Phrases</p>
-              <textarea
-                name="words"
-                className="w-full secondary-text h-full min-h-60 resize-none p-3 rounded-lg input text-lg"
-                placeholder={
-                  "Enter words in the target language, with each word on a new line. For example:\nabacaxi\nfalar\npalavra"
-                }
-                value={words}
-                onChange={(e) => setWords(e.target.value)}
-              />
-            </motion.div>
-            <div className="flex flex-row w-full justify-center my-8">
-              <motion.div
-                initial={{ opacity: 0, y: 100 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.75, delay: 1.25 }}
-              >
-                <motion.button
-                  className="button"
-                  whileHover={!words ? undefined : { scale: 1.05 }}
-                  disabled={!words}
-                  onClick={() => {
-                    setInputFields((oldFields) => ({
-                      ...oldFields,
-                      words: words,
-                    }));
-                  }}
-                >
-                  Continue
-                </motion.button>
-              </motion.div>
-            </div>
-          </div>
-        </motion.div>
+        <WordTextArea setInputFields={setInputFields} />
       ) : (
-        <motion.div
-          key="resources-selection"
-          className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0, transition: { duration: 0.75 } }}
-        >
-          <div className="py-8 flex flex-col justify-center w-full min-h-full">
-            <div>
-              <motion.button
-                initial={{ opacity: 0, y: -100 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.75, delay: 1.25 }}
-                onClick={() =>
-                  setInputFields((oldFields) => {
-                    return { ...oldFields, words: "" } as InputFields;
-                  })
-                }
-                className="text-lg flex items-center"
-              >
-                <div className="group hover:cursor-pointer flex items-center">
-                  <div className="flex flex-col justify-center items-start">
-                    <IoChevronBackOutline color="#162e50" />
-                    <div className="h-0.5" />
-                  </div>
-                  <div className="flex flex-col justify-center items-start">
-                    <p className="mx-1 secondary-text">Go back</p>
-                    <div
-                      className={
-                        "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
-                      }
-                    />
-                  </div>
-                </div>
-              </motion.button>
-              <motion.p
-                className="text-3xl font-bold text-center my-4"
-                initial={{ opacity: 0, y: -100 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.75, delay: 0.5 }}
-              >
-                Select resources
-              </motion.p>
-              <motion.div
-                className="flex-1 flex flex-col w-full my-4"
-                variants={{
-                  hidden: { opacity: 0, x: 100 },
-                  visible: { opacity: 1, x: 0 },
-                  exit: {
-                    opacity: 0,
-                    transition: { duration: 0.75 },
-                  },
-                }}
-                initial="hidden"
-                animate="visible"
-                exit="exit"
-                transition={{ duration: 0.75, delay: 0.75 }}
-              >
-                <p className="text-lg my-2">
-                  Select the resource(s) you would like to use to generate the
-                  flashcards:
-                </p>
-
-                {languageResources.map((resource, index) => {
-                  return (
-                    <motion.label
-                      key={resource.name + targetLanguage + index}
-                      className="flex flex-row items-center text-lg"
-                      variants={{
-                        hidden: { opacity: 0, x: 100 },
-                        visible: { opacity: 1, x: 0 },
-                      }}
-                      initial="hidden"
-                      animate="visible"
-                      transition={{
-                        duration: 0.75,
-                        delay: (index + 1) * 0.25 + 0.5,
-                      }}
-                    >
-                      <input
-                        name={resource.name}
-                        type="checkbox"
-                        className="mx-2 hidden"
-                        checked={resource.isSelected ?? false}
-                        onChange={(e) => handleResourceCheckboxChange(e)}
-                      />
-                      <div className="mx-2">
-                        {resource.isSelected ? (
-                          <MdCheckBox color="#162e50" size={24} />
-                        ) : (
-                          <MdCheckBoxOutlineBlank color="#162e50" size={24} />
-                        )}
-                      </div>
-                      {resource.name}
-                      <div
-                        className={`mx-2 w-4 h-4 rounded-full relative ${
-                          resource.isHealthy
-                            ? "green-background"
-                            : "accent-background"
-                        }`}
-                      >
-                        <div className="absolute z-50 opacity-0 hover:opacity-100 w-max bg-white px-2 p-1 rounded-lg text-sm -top-1 transition-all duration-300">
-                          {resource.isHealthy
-                            ? "Working as expected"
-                            : "Might be blocked or broken"}
-                        </div>
-                      </div>
-                    </motion.label>
-                  );
-                })}
-              </motion.div>
-              <div className="flex flex-row justify-center my-8">
-                <motion.div
-                  initial={{ opacity: 0, y: 100 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.75, delay: 1.25 }}
-                >
-                  <motion.button
-                    onClick={handleSubmit}
-                    whileHover={
-                      !languageResources.some((resource) => resource.isSelected)
-                        ? undefined
-                        : { scale: 1.05 }
-                    }
-                    disabled={
-                      !languageResources.some((resource) => resource.isSelected)
-                    }
-                    className="button"
-                  >
-                    Generate
-                  </motion.button>
-                </motion.div>
-              </div>
-            </div>
-          </div>
-        </motion.div>
+        <ResourceSelector
+          inputFields={inputFields}
+          setIsLoading={setIsLoading}
+          setScrapedData={setScrapedData}
+          setInputFields={setInputFields}
+          setLanguageResources={setLanguageResources}
+          languageResources={languageResources}
+        />
       )}
     </AnimatePresence>
   );

--- a/src/components/forms/resource-form/LanguageSelector.tsx
+++ b/src/components/forms/resource-form/LanguageSelector.tsx
@@ -1,0 +1,127 @@
+import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import FormError from "../FormError";
+import { InputFields } from "../../../types/types";
+
+type Props = {
+  setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
+};
+
+export default function LanguageSelector({ setInputFields }: Props) {
+  const [supportedLanguages, setSupportedLanguages] = useState<string[]>([]);
+  const [targetLanguage, setTargetLanguage] = useState<string>("");
+  const [nativeLanguage, setNativeLanguage] = useState<string>("");
+
+  useEffect(() => {
+    fetch("api/supported-languages")
+      .then((res) => res.json())
+      .then((data) => setSupportedLanguages(data.languages));
+  }, []);
+
+  return (
+    <motion.div
+      key="language-selection"
+      className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{
+        opacity: 0,
+        transition: { ease: "easeInOut", duration: 0.75 },
+      }}
+    >
+      <div>
+        <motion.p
+          className="text-3xl font-bold text-center my-4"
+          initial={{ opacity: 0, y: -100 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 0.5 }}
+        >
+          Enter your target language and native language
+        </motion.p>
+        <motion.div
+          className="mb-4 flex flex-col w-full"
+          initial={{ opacity: 0, x: 100 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.75, delay: 0.75 }}
+        >
+          <p className="font-bold secondary-text">Target language</p>
+          <select
+            name="targetLanguage"
+            className="secondary-text p-2 pr-8 rounded-lg input text-lg"
+            value={targetLanguage}
+            onChange={(e) => setTargetLanguage(e.target.value)}
+          >
+            <option value="">Select target language</option>
+            {supportedLanguages.map((language, index) => (
+              <option key={index} value={language}>
+                {language}
+              </option>
+            ))}
+          </select>
+          {targetLanguage && targetLanguage === nativeLanguage && (
+            <FormError
+              message={"Target language must be different from native language"}
+            />
+          )}
+        </motion.div>
+        <motion.div
+          className="mb-4 flex flex-col w-full"
+          initial={{ opacity: 0, x: 100 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.75, delay: 1 }}
+        >
+          <p className="font-bold secondary-text">Native language</p>
+          <select
+            name="nativeLanguage"
+            className="secondary-text p-2 pr-8 rounded-lg input text-lg"
+            value={nativeLanguage}
+            onChange={(e) => setNativeLanguage(e.target.value)}
+          >
+            <option value="">Select native language</option>
+            {supportedLanguages.map((language, index) => (
+              <option key={index} value={language}>
+                {language}
+              </option>
+            ))}
+          </select>
+          {nativeLanguage && nativeLanguage === targetLanguage && (
+            <FormError
+              message={"Native language must be different from target language"}
+            />
+          )}
+        </motion.div>
+      </div>
+      <div className="flex flex-row w-full justify-center my-8">
+        <motion.div
+          initial={{ opacity: 0, y: 100 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 1.25 }}
+        >
+          <motion.button
+            className="button"
+            whileHover={
+              !nativeLanguage ||
+              !targetLanguage ||
+              nativeLanguage === targetLanguage
+                ? undefined
+                : { scale: 1.05 }
+            }
+            disabled={
+              !nativeLanguage ||
+              !targetLanguage ||
+              nativeLanguage === targetLanguage
+            }
+            onClick={() => {
+              setInputFields({
+                nativeLanguage: nativeLanguage,
+                targetLanguage: targetLanguage,
+              } as InputFields);
+            }}
+          >
+            Continue
+          </motion.button>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/forms/resource-form/LanguageSelector.tsx
+++ b/src/components/forms/resource-form/LanguageSelector.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import FormError from "../FormError";
-import { InputFields } from "../../../types/types";
+import type { InputFields } from "../../../types/types";
 
 type Props = {
   setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
@@ -19,16 +19,7 @@ export default function LanguageSelector({ setInputFields }: Props) {
   }, []);
 
   return (
-    <motion.div
-      key="language-selection"
-      className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{
-        opacity: 0,
-        transition: { ease: "easeInOut", duration: 0.75 },
-      }}
-    >
+    <div>
       <div>
         <motion.p
           className="text-3xl font-bold text-center my-4"
@@ -122,6 +113,6 @@ export default function LanguageSelector({ setInputFields }: Props) {
           </motion.button>
         </motion.div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/src/components/forms/resource-form/ResourceSelector.tsx
+++ b/src/components/forms/resource-form/ResourceSelector.tsx
@@ -1,0 +1,187 @@
+import { motion } from "framer-motion";
+import { CombinedScrapedResponse, InputFields, LanguageResource, ScrapedResponse } from "../../../types/types";
+import { IoChevronBackOutline } from "react-icons/io5";
+import { getFlashcardData } from "../utils/getFlashcardData";
+import { MdCheckBox, MdCheckBoxOutlineBlank } from "react-icons/md";
+
+type Props = {
+  inputFields: InputFields;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  setScrapedData: React.Dispatch<
+    React.SetStateAction<(CombinedScrapedResponse | ScrapedResponse)[]>
+  >;
+  setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
+  setLanguageResources: React.Dispatch<
+    React.SetStateAction<LanguageResource[]>
+  >;
+  languageResources: LanguageResource[];
+};
+
+export default function ResourceSelector({
+  setInputFields,
+  setLanguageResources,
+  languageResources,
+  setIsLoading,
+  inputFields,
+  setScrapedData,
+}: Props) {
+  function handleResourceCheckboxChange(
+    e: React.ChangeEvent<HTMLInputElement>
+  ) {
+    const newCheckboxField = languageResources.map((field) => {
+      if (field.name === e.target.name) {
+        field.isSelected = !field.isSelected;
+      }
+      return field;
+    });
+    setLanguageResources(newCheckboxField);
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setIsLoading(true);
+    getFlashcardData({ ...inputFields, languageResources }).then((res) => {
+      setScrapedData(res);
+      setIsLoading(false);
+    });
+  }
+
+  return (
+    <motion.div
+      key="resources-selection"
+      className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0, transition: { duration: 0.75 } }}
+    >
+      <div className="py-8 flex flex-col justify-center w-full min-h-full">
+        <div>
+          <motion.button
+            initial={{ opacity: 0, y: -100 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.75, delay: 1.25 }}
+            onClick={() =>
+              setInputFields((oldFields) => {
+                return { ...oldFields, words: "" } as InputFields;
+              })
+            }
+            className="text-lg flex items-center"
+          >
+            <div className="group hover:cursor-pointer flex items-center">
+              <div className="flex flex-col justify-center items-start">
+                <IoChevronBackOutline color="#162e50" />
+                <div className="h-0.5" />
+              </div>
+              <div className="flex flex-col justify-center items-start">
+                <p className="mx-1 secondary-text">Go back</p>
+                <div
+                  className={
+                    "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
+                  }
+                />
+              </div>
+            </div>
+          </motion.button>
+          <motion.p
+            className="text-3xl font-bold text-center my-4"
+            initial={{ opacity: 0, y: -100 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.75, delay: 0.5 }}
+          >
+            Select resources
+          </motion.p>
+          <motion.div
+            className="flex-1 flex flex-col w-full my-4"
+            variants={{
+              hidden: { opacity: 0, x: 100 },
+              visible: { opacity: 1, x: 0 },
+              exit: {
+                opacity: 0,
+                transition: { duration: 0.75 },
+              },
+            }}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            transition={{ duration: 0.75, delay: 0.75 }}
+          >
+            <p className="text-lg my-2">
+              Select the resource(s) you would like to use to generate the
+              flashcards:
+            </p>
+
+            {languageResources.map((resource, index) => {
+              return (
+                <motion.label
+                  key={resource.name + inputFields.targetLanguage + index}
+                  className="flex flex-row items-center text-lg"
+                  variants={{
+                    hidden: { opacity: 0, x: 100 },
+                    visible: { opacity: 1, x: 0 },
+                  }}
+                  initial="hidden"
+                  animate="visible"
+                  transition={{
+                    duration: 0.75,
+                    delay: (index + 1) * 0.25 + 0.5,
+                  }}
+                >
+                  <input
+                    name={resource.name}
+                    type="checkbox"
+                    className="mx-2 hidden"
+                    checked={resource.isSelected ?? false}
+                    onChange={(e) => handleResourceCheckboxChange(e)}
+                  />
+                  <div className="mx-2">
+                    {resource.isSelected ? (
+                      <MdCheckBox color="#162e50" size={24} />
+                    ) : (
+                      <MdCheckBoxOutlineBlank color="#162e50" size={24} />
+                    )}
+                  </div>
+                  {resource.name}
+                  <div
+                    className={`mx-2 w-4 h-4 rounded-full relative ${
+                      resource.isHealthy
+                        ? "green-background"
+                        : "accent-background"
+                    }`}
+                  >
+                    <div className="absolute z-50 opacity-0 hover:opacity-100 w-max bg-white px-2 p-1 rounded-lg text-sm -top-1 transition-all duration-300">
+                      {resource.isHealthy
+                        ? "Working as expected"
+                        : "Might be blocked or broken"}
+                    </div>
+                  </div>
+                </motion.label>
+              );
+            })}
+          </motion.div>
+          <div className="flex flex-row justify-center my-8">
+            <motion.div
+              initial={{ opacity: 0, y: 100 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.75, delay: 1.25 }}
+            >
+              <motion.button
+                onClick={handleSubmit}
+                whileHover={
+                  !languageResources.some((resource) => resource.isSelected)
+                    ? undefined
+                    : { scale: 1.05 }
+                }
+                disabled={
+                  !languageResources.some((resource) => resource.isSelected)
+                }
+                className="button"
+              >
+                Generate
+              </motion.button>
+            </motion.div>
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/forms/resource-form/ResourceSelector.tsx
+++ b/src/components/forms/resource-form/ResourceSelector.tsx
@@ -1,15 +1,16 @@
 import { motion } from "framer-motion";
-import { CombinedScrapedResponse, InputFields, LanguageResource, ScrapedResponse } from "../../../types/types";
+import type {
+  InputFields,
+  LanguageResource,
+} from "../../../types/types";
 import { IoChevronBackOutline } from "react-icons/io5";
 import { getFlashcardData } from "../utils/getFlashcardData";
 import { MdCheckBox, MdCheckBoxOutlineBlank } from "react-icons/md";
+import { useDispatch } from "react-redux";
+import { setIsLoading, setScrapedData } from "../../../store/slice";
 
 type Props = {
   inputFields: InputFields;
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
-  setScrapedData: React.Dispatch<
-    React.SetStateAction<(CombinedScrapedResponse | ScrapedResponse)[]>
-  >;
   setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
   setLanguageResources: React.Dispatch<
     React.SetStateAction<LanguageResource[]>
@@ -21,10 +22,10 @@ export default function ResourceSelector({
   setInputFields,
   setLanguageResources,
   languageResources,
-  setIsLoading,
   inputFields,
-  setScrapedData,
 }: Props) {
+  const dispatch = useDispatch();
+
   function handleResourceCheckboxChange(
     e: React.ChangeEvent<HTMLInputElement>
   ) {
@@ -39,149 +40,141 @@ export default function ResourceSelector({
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setIsLoading(true);
+    dispatch(setIsLoading(true));
     getFlashcardData({ ...inputFields, languageResources }).then((res) => {
-      setScrapedData(res);
-      setIsLoading(false);
+      dispatch(setScrapedData(res));
+      dispatch(setIsLoading(false));
     });
   }
 
   return (
-    <motion.div
-      key="resources-selection"
-      className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0, transition: { duration: 0.75 } }}
-    >
-      <div className="py-8 flex flex-col justify-center w-full min-h-full">
-        <div>
-          <motion.button
-            initial={{ opacity: 0, y: -100 }}
+    <div className="py-8 flex flex-col justify-center w-full min-h-full">
+      <div>
+        <motion.button
+          initial={{ opacity: 0, y: -100 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 1.25 }}
+          onClick={() =>
+            setInputFields((oldFields) => {
+              return { ...oldFields, words: "" } as InputFields;
+            })
+          }
+          className="text-lg flex items-center"
+        >
+          <div className="group hover:cursor-pointer flex items-center">
+            <div className="flex flex-col justify-center items-start">
+              <IoChevronBackOutline color="#162e50" />
+              <div className="h-0.5" />
+            </div>
+            <div className="flex flex-col justify-center items-start">
+              <p className="mx-1 secondary-text">Go back</p>
+              <div
+                className={
+                  "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
+                }
+              />
+            </div>
+          </div>
+        </motion.button>
+        <motion.p
+          className="text-3xl font-bold text-center my-4"
+          initial={{ opacity: 0, y: -100 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 0.5 }}
+        >
+          Select resources
+        </motion.p>
+        <motion.div
+          className="flex-1 flex flex-col w-full my-4"
+          variants={{
+            hidden: { opacity: 0, x: 100 },
+            visible: { opacity: 1, x: 0 },
+            exit: {
+              opacity: 0,
+              transition: { duration: 0.75 },
+            },
+          }}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          transition={{ duration: 0.75, delay: 0.75 }}
+        >
+          <p className="text-lg my-2">
+            Select the resource(s) you would like to use to generate the
+            flashcards:
+          </p>
+
+          {languageResources.map((resource, index) => {
+            return (
+              <motion.label
+                key={resource.name + inputFields.targetLanguage + index}
+                className="flex flex-row items-center text-lg"
+                variants={{
+                  hidden: { opacity: 0, x: 100 },
+                  visible: { opacity: 1, x: 0 },
+                }}
+                initial="hidden"
+                animate="visible"
+                transition={{
+                  duration: 0.75,
+                  delay: (index + 1) * 0.25 + 0.5,
+                }}
+              >
+                <input
+                  name={resource.name}
+                  type="checkbox"
+                  className="mx-2 hidden"
+                  checked={resource.isSelected ?? false}
+                  onChange={(e) => handleResourceCheckboxChange(e)}
+                />
+                <div className="mx-2">
+                  {resource.isSelected ? (
+                    <MdCheckBox color="#162e50" size={24} />
+                  ) : (
+                    <MdCheckBoxOutlineBlank color="#162e50" size={24} />
+                  )}
+                </div>
+                {resource.name}
+                <div
+                  className={`mx-2 w-4 h-4 rounded-full relative ${
+                    resource.isHealthy
+                      ? "green-background"
+                      : "accent-background"
+                  }`}
+                >
+                  <div className="absolute z-50 opacity-0 hover:opacity-100 w-max bg-white px-2 p-1 rounded-lg text-sm -top-1 transition-all duration-300">
+                    {resource.isHealthy
+                      ? "Working as expected"
+                      : "Might be blocked or broken"}
+                  </div>
+                </div>
+              </motion.label>
+            );
+          })}
+        </motion.div>
+        <div className="flex flex-row justify-center my-8">
+          <motion.div
+            initial={{ opacity: 0, y: 100 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.75, delay: 1.25 }}
-            onClick={() =>
-              setInputFields((oldFields) => {
-                return { ...oldFields, words: "" } as InputFields;
-              })
-            }
-            className="text-lg flex items-center"
           >
-            <div className="group hover:cursor-pointer flex items-center">
-              <div className="flex flex-col justify-center items-start">
-                <IoChevronBackOutline color="#162e50" />
-                <div className="h-0.5" />
-              </div>
-              <div className="flex flex-col justify-center items-start">
-                <p className="mx-1 secondary-text">Go back</p>
-                <div
-                  className={
-                    "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
-                  }
-                />
-              </div>
-            </div>
-          </motion.button>
-          <motion.p
-            className="text-3xl font-bold text-center my-4"
-            initial={{ opacity: 0, y: -100 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.75, delay: 0.5 }}
-          >
-            Select resources
-          </motion.p>
-          <motion.div
-            className="flex-1 flex flex-col w-full my-4"
-            variants={{
-              hidden: { opacity: 0, x: 100 },
-              visible: { opacity: 1, x: 0 },
-              exit: {
-                opacity: 0,
-                transition: { duration: 0.75 },
-              },
-            }}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-            transition={{ duration: 0.75, delay: 0.75 }}
-          >
-            <p className="text-lg my-2">
-              Select the resource(s) you would like to use to generate the
-              flashcards:
-            </p>
-
-            {languageResources.map((resource, index) => {
-              return (
-                <motion.label
-                  key={resource.name + inputFields.targetLanguage + index}
-                  className="flex flex-row items-center text-lg"
-                  variants={{
-                    hidden: { opacity: 0, x: 100 },
-                    visible: { opacity: 1, x: 0 },
-                  }}
-                  initial="hidden"
-                  animate="visible"
-                  transition={{
-                    duration: 0.75,
-                    delay: (index + 1) * 0.25 + 0.5,
-                  }}
-                >
-                  <input
-                    name={resource.name}
-                    type="checkbox"
-                    className="mx-2 hidden"
-                    checked={resource.isSelected ?? false}
-                    onChange={(e) => handleResourceCheckboxChange(e)}
-                  />
-                  <div className="mx-2">
-                    {resource.isSelected ? (
-                      <MdCheckBox color="#162e50" size={24} />
-                    ) : (
-                      <MdCheckBoxOutlineBlank color="#162e50" size={24} />
-                    )}
-                  </div>
-                  {resource.name}
-                  <div
-                    className={`mx-2 w-4 h-4 rounded-full relative ${
-                      resource.isHealthy
-                        ? "green-background"
-                        : "accent-background"
-                    }`}
-                  >
-                    <div className="absolute z-50 opacity-0 hover:opacity-100 w-max bg-white px-2 p-1 rounded-lg text-sm -top-1 transition-all duration-300">
-                      {resource.isHealthy
-                        ? "Working as expected"
-                        : "Might be blocked or broken"}
-                    </div>
-                  </div>
-                </motion.label>
-              );
-            })}
-          </motion.div>
-          <div className="flex flex-row justify-center my-8">
-            <motion.div
-              initial={{ opacity: 0, y: 100 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.75, delay: 1.25 }}
+            <motion.button
+              onClick={handleSubmit}
+              whileHover={
+                !languageResources.some((resource) => resource.isSelected)
+                  ? undefined
+                  : { scale: 1.05 }
+              }
+              disabled={
+                !languageResources.some((resource) => resource.isSelected)
+              }
+              className="button"
             >
-              <motion.button
-                onClick={handleSubmit}
-                whileHover={
-                  !languageResources.some((resource) => resource.isSelected)
-                    ? undefined
-                    : { scale: 1.05 }
-                }
-                disabled={
-                  !languageResources.some((resource) => resource.isSelected)
-                }
-                className="button"
-              >
-                Generate
-              </motion.button>
-            </motion.div>
-          </div>
+              Generate
+            </motion.button>
+          </motion.div>
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/src/components/forms/resource-form/WordTextArea.tsx
+++ b/src/components/forms/resource-form/WordTextArea.tsx
@@ -1,0 +1,93 @@
+import { motion } from "framer-motion";
+import { InputFields } from "../../../types/types";
+import { IoChevronBackOutline } from "react-icons/io5";
+import { useState } from "react";
+
+type Props = {
+  setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
+}
+
+export default function WordTextArea({ setInputFields }: Props) {
+  const [words, setWords] = useState<string>("");
+
+  return (
+    <motion.div
+      key="word-entry"
+      className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0, transition: { duration: 0.75 } }}
+    >
+      <div>
+        <motion.button
+          initial={{ opacity: 0, y: -100 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 1.25 }}
+          onClick={() => setInputFields({} as InputFields)}
+          className="text-lg flex items-center"
+        >
+          <div className="group hover:cursor-pointer flex items-center">
+            <div className="flex flex-col justify-center items-start">
+              <IoChevronBackOutline color="#162e50" />
+              <div className="h-0.5" />
+            </div>
+            <div className="flex flex-col justify-center items-start">
+              <p className="mx-1 secondary-text">Go back</p>
+              <div
+                className={
+                  "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
+                }
+              />
+            </div>
+          </div>
+        </motion.button>
+        <motion.p
+          className="text-3xl font-bold text-center my-4"
+          initial={{ opacity: 0, y: -100 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 0.5 }}
+        >
+          Enter words and/or phrases in the target language
+        </motion.p>
+        <motion.div
+          className="mb-4 flex flex-col w-full"
+          initial={{ opacity: 0, y: 100 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 0.75 }}
+        >
+          <p className="font-bold secondary-text">Words/Phrases</p>
+          <textarea
+            name="words"
+            className="w-full secondary-text h-full min-h-60 resize-none p-3 rounded-lg input text-lg"
+            placeholder={
+              "Enter words in the target language, with each word on a new line. For example:\nabacaxi\nfalar\npalavra"
+            }
+            value={words}
+            onChange={(e) => setWords(e.target.value)}
+          />
+        </motion.div>
+        <div className="flex flex-row w-full justify-center my-8">
+          <motion.div
+            initial={{ opacity: 0, y: 100 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.75, delay: 1.25 }}
+          >
+            <motion.button
+              className="button"
+              whileHover={!words ? undefined : { scale: 1.05 }}
+              disabled={!words}
+              onClick={() => {
+                setInputFields((oldFields) => ({
+                  ...oldFields,
+                  words: words,
+                }));
+              }}
+            >
+              Continue
+            </motion.button>
+          </motion.div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/forms/resource-form/WordTextArea.tsx
+++ b/src/components/forms/resource-form/WordTextArea.tsx
@@ -1,93 +1,85 @@
 import { motion } from "framer-motion";
-import { InputFields } from "../../../types/types";
+import type { InputFields } from "../../../types/types";
 import { IoChevronBackOutline } from "react-icons/io5";
 import { useState } from "react";
 
 type Props = {
   setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
-}
+};
 
 export default function WordTextArea({ setInputFields }: Props) {
   const [words, setWords] = useState<string>("");
 
   return (
-    <motion.div
-      key="word-entry"
-      className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0, transition: { duration: 0.75 } }}
-    >
-      <div>
-        <motion.button
-          initial={{ opacity: 0, y: -100 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.75, delay: 1.25 }}
-          onClick={() => setInputFields({} as InputFields)}
-          className="text-lg flex items-center"
-        >
-          <div className="group hover:cursor-pointer flex items-center">
-            <div className="flex flex-col justify-center items-start">
-              <IoChevronBackOutline color="#162e50" />
-              <div className="h-0.5" />
-            </div>
-            <div className="flex flex-col justify-center items-start">
-              <p className="mx-1 secondary-text">Go back</p>
-              <div
-                className={
-                  "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
-                }
-              />
-            </div>
+    <div>
+      <motion.button
+        initial={{ opacity: 0, y: -100 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.75, delay: 1.25 }}
+        onClick={() => setInputFields({} as InputFields)}
+        className="text-lg flex items-center"
+      >
+        <div className="group hover:cursor-pointer flex items-center">
+          <div className="flex flex-col justify-center items-start">
+            <IoChevronBackOutline color="#162e50" />
+            <div className="h-0.5" />
           </div>
-        </motion.button>
-        <motion.p
-          className="text-3xl font-bold text-center my-4"
-          initial={{ opacity: 0, y: -100 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.75, delay: 0.5 }}
-        >
-          Enter words and/or phrases in the target language
-        </motion.p>
+          <div className="flex flex-col justify-center items-start">
+            <p className="mx-1 secondary-text">Go back</p>
+            <div
+              className={
+                "max-w-0 group-hover:max-w-full transition-all duration-300 rounded-full w-full h-0.5 bg-black"
+              }
+            />
+          </div>
+        </div>
+      </motion.button>
+      <motion.p
+        className="text-3xl font-bold text-center my-4"
+        initial={{ opacity: 0, y: -100 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.75, delay: 0.5 }}
+      >
+        Enter words and/or phrases in the target language
+      </motion.p>
+      <motion.div
+        className="mb-4 flex flex-col w-full"
+        initial={{ opacity: 0, y: 100 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.75, delay: 0.75 }}
+      >
+        <p className="font-bold secondary-text">Words/Phrases</p>
+        <textarea
+          name="words"
+          className="w-full secondary-text h-full min-h-60 resize-none p-3 rounded-lg input text-lg"
+          placeholder={
+            "Enter words in the target language, with each word on a new line. For example:\nabacaxi\nfalar\npalavra"
+          }
+          value={words}
+          onChange={(e) => setWords(e.target.value)}
+        />
+      </motion.div>
+      <div className="flex flex-row w-full justify-center my-8">
         <motion.div
-          className="mb-4 flex flex-col w-full"
           initial={{ opacity: 0, y: 100 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.75, delay: 0.75 }}
+          transition={{ duration: 0.75, delay: 1.25 }}
         >
-          <p className="font-bold secondary-text">Words/Phrases</p>
-          <textarea
-            name="words"
-            className="w-full secondary-text h-full min-h-60 resize-none p-3 rounded-lg input text-lg"
-            placeholder={
-              "Enter words in the target language, with each word on a new line. For example:\nabacaxi\nfalar\npalavra"
-            }
-            value={words}
-            onChange={(e) => setWords(e.target.value)}
-          />
-        </motion.div>
-        <div className="flex flex-row w-full justify-center my-8">
-          <motion.div
-            initial={{ opacity: 0, y: 100 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.75, delay: 1.25 }}
+          <motion.button
+            className="button"
+            whileHover={!words ? undefined : { scale: 1.05 }}
+            disabled={!words}
+            onClick={() => {
+              setInputFields((oldFields) => ({
+                ...oldFields,
+                words: words,
+              }));
+            }}
           >
-            <motion.button
-              className="button"
-              whileHover={!words ? undefined : { scale: 1.05 }}
-              disabled={!words}
-              onClick={() => {
-                setInputFields((oldFields) => ({
-                  ...oldFields,
-                  words: words,
-                }));
-              }}
-            >
-              Continue
-            </motion.button>
-          </motion.div>
-        </div>
+            Continue
+          </motion.button>
+        </motion.div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,15 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "./store/index.ts";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>
 );

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,18 +1,17 @@
 import { useState } from "react";
 import Loading from "../components/Loading";
-import {
-  CombinedScrapedResponse,
-  WordScrapeError,
-} from "../types/types";
+import type { WordScrapeError } from "../types/types";
 import ResourceForm from "../components/forms/ResourceForm";
 import CardFormatForm from "../components/forms/CardFormatForm";
 import Download from "../components/Download";
+import { useSelector } from "react-redux";
+import type { RootState } from "../store";
 
 export default function Main() {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [scrapedData, setScrapedData] = useState<CombinedScrapedResponse[]>([]);
   const [downloadUrl, setDownloadUrl] = useState<string>("");
   const [exportFields, setExportFields] = useState<string[]>([]);
+  const isLoading = useSelector((state: RootState) => state.root.isLoading);
+  const scrapedData = useSelector((state: RootState) => state.root.scrapedData);
 
   function getErrors(): WordScrapeError[] {
     return scrapedData
@@ -45,10 +44,8 @@ export default function Main() {
     return (
       <div className="w-full h-screen route-component">
         <CardFormatForm
-          scrapedData={scrapedData}
           exportFields={exportFields}
           setDownloadUrl={setDownloadUrl}
-          setIsLoading={setIsLoading}
         />
       </div>
     );
@@ -56,11 +53,7 @@ export default function Main() {
 
   return (
     <div className="w-full h-screen route-component">
-      <ResourceForm
-        setIsLoading={setIsLoading}
-        setScrapedData={setScrapedData}
-        setExportFields={setExportFields}
-      />
+      <ResourceForm setExportFields={setExportFields} />
     </div>
   );
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,12 @@
+import { configureStore } from "@reduxjs/toolkit";
+import rootReducer from "./slice";
+
+const store = configureStore({
+  reducer: {
+    root: rootReducer,
+  },
+});
+
+export default store;
+export type RootState = ReturnType<typeof store.getState>;
+

--- a/src/store/slice.ts
+++ b/src/store/slice.ts
@@ -1,0 +1,21 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { CombinedScrapedResponse } from "../types/types";
+
+const slice = createSlice({
+  name: "root",
+  initialState: {
+    isLoading: false,
+    scrapedData: [] as CombinedScrapedResponse[],
+  },
+  reducers: {
+    setIsLoading: (state, action) => {
+      state.isLoading = action.payload;
+    },
+    setScrapedData: (state, action) => {
+      state.scrapedData = action.payload;
+    },
+  },
+});
+
+export const { setIsLoading, setScrapedData } = slice.actions;
+export default slice.reducer;


### PR DESCRIPTION
### Summary of changes
1. Refactor ResourceForm.tsx to have components for each page in the form
2. Implement Redux
3. Add `import type` where possible
4. Update deprecated api methods
5. Updates link on DownloadPage to point to the README instead of the repo

### Description
Refactors `ResourceForm.tsx` to use individual components for each page of the form. The three pages have been moved to `resource-form/LanguageSelector.tsx`, `resource-form/ResourceSelector.tsx` and `resource-form/WordTextArea.tsx`.

To avoid prop-drilling, Redux has been implemented. The store consists of a single slice that manages `isLoading` and `scrapedData`.

Added `import type` when possible to reduce bundle size and improve clarity.

Also, there were a couple deprecated functions in the API that were updated:
1. `findChildren` -> `find_all`
6. `findAll` -> `find_all`

Finally, updated the link on `DownloadPage.tsx` to point to the README of the repo, instead of just linking to the repo.