### PR TITLE
[Fix]: Preserve previously entered input when going back

### DIFF
--- a/src/components/forms/ResourceForm.tsx
+++ b/src/components/forms/ResourceForm.tsx
@@ -16,6 +16,9 @@ export default function ResourceForm({ setExportFields }: Props) {
   const [inputFields, setInputFields] = useState<InputFields>(
     {} as InputFields
   );
+  const [currentStep, setCurrentStep] = useState<
+    "languages" | "words" | "resources"
+  >("languages");
 
   useEffect(() => {
     setLanguageResources([]);
@@ -55,54 +58,60 @@ export default function ResourceForm({ setExportFields }: Props) {
   return (
     <AnimatePresence mode="wait">
       {((): ReactNode => {
-        if (
-          !inputFields.targetLanguage ||
-          !inputFields.nativeLanguage ||
-          inputFields.targetLanguage === inputFields.nativeLanguage
-        ) {
-          return (
-            <motion.div
-              key="language-selection"
-              className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{
-                opacity: 0,
-                transition: { ease: "easeInOut", duration: 0.75 },
-              }}
-            >
-              <LanguageSelector setInputFields={setInputFields} />
-            </motion.div>
-          );
-        } else if (!inputFields.words) {
-          return (
-            <motion.div
-              key="word-entry"
-              className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0, transition: { duration: 0.75 } }}
-            >
-              <WordTextArea setInputFields={setInputFields} />
-            </motion.div>
-          );
-        } else {
-          return (
-            <motion.div
-              key="resources-selection"
-              className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0, transition: { duration: 0.75 } }}
-            >
-              <ResourceSelector
-                inputFields={inputFields}
-                setInputFields={setInputFields}
-                setLanguageResources={setLanguageResources}
-                languageResources={languageResources}
-              />
-            </motion.div>
-          );
+        switch (currentStep) {
+          case "languages":
+            return (
+              <motion.div
+                key="language-selection"
+                className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{
+                  opacity: 0,
+                  transition: { ease: "easeInOut", duration: 0.75 },
+                }}
+              >
+                <LanguageSelector
+                  inputFields={inputFields}
+                  setInputFields={setInputFields}
+                  goToNextStep={() => setCurrentStep("words")}
+                />
+              </motion.div>
+            );
+          case "words":
+            return (
+              <motion.div
+                key="word-entry"
+                className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0, transition: { duration: 0.75 } }}
+              >
+                <WordTextArea
+                  inputFields={inputFields}
+                  setInputFields={setInputFields}
+                  goToPreviousStep={() => setCurrentStep("languages")}
+                  goToNextStep={() => setCurrentStep("resources")}
+                />
+              </motion.div>
+            );
+          case "resources":
+            return (
+              <motion.div
+                key="resources-selection"
+                className="py-8 px-8 sm:px-16 md:px-24 lg:px-64 flex flex-col justify-center w-full min-h-full"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0, transition: { duration: 0.75 } }}
+              >
+                <ResourceSelector
+                  inputFields={inputFields}
+                  setLanguageResources={setLanguageResources}
+                  languageResources={languageResources}
+                  goToPreviousStep={() => setCurrentStep("words")}
+                />
+              </motion.div>
+            );
         }
       })()}
     </AnimatePresence>

--- a/src/components/forms/resource-form/LanguageSelector.tsx
+++ b/src/components/forms/resource-form/LanguageSelector.tsx
@@ -5,12 +5,22 @@ import type { InputFields } from "../../../types/types";
 
 type Props = {
   setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
+  inputFields: InputFields;
+  goToNextStep: () => void;
 };
 
-export default function LanguageSelector({ setInputFields }: Props) {
+export default function LanguageSelector({
+  setInputFields,
+  inputFields,
+  goToNextStep,
+}: Props) {
   const [supportedLanguages, setSupportedLanguages] = useState<string[]>([]);
-  const [targetLanguage, setTargetLanguage] = useState<string>("");
-  const [nativeLanguage, setNativeLanguage] = useState<string>("");
+  const [targetLanguage, setTargetLanguage] = useState<string>(
+    inputFields.targetLanguage || ""
+  );
+  const [nativeLanguage, setNativeLanguage] = useState<string>(
+    inputFields.nativeLanguage || ""
+  );
 
   useEffect(() => {
     fetch("api/supported-languages")
@@ -103,10 +113,12 @@ export default function LanguageSelector({ setInputFields }: Props) {
               nativeLanguage === targetLanguage
             }
             onClick={() => {
-              setInputFields({
+              setInputFields((oldFields) => ({
+                ...oldFields,
                 nativeLanguage: nativeLanguage,
                 targetLanguage: targetLanguage,
-              } as InputFields);
+              }));
+              goToNextStep();
             }}
           >
             Continue

--- a/src/components/forms/resource-form/ResourceSelector.tsx
+++ b/src/components/forms/resource-form/ResourceSelector.tsx
@@ -11,18 +11,18 @@ import { setIsLoading, setScrapedData } from "../../../store/slice";
 
 type Props = {
   inputFields: InputFields;
-  setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
   setLanguageResources: React.Dispatch<
     React.SetStateAction<LanguageResource[]>
   >;
   languageResources: LanguageResource[];
+  goToPreviousStep: () => void;
 };
 
 export default function ResourceSelector({
-  setInputFields,
   setLanguageResources,
   languageResources,
   inputFields,
+  goToPreviousStep,
 }: Props) {
   const dispatch = useDispatch();
 
@@ -54,11 +54,7 @@ export default function ResourceSelector({
           initial={{ opacity: 0, y: -100 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.75, delay: 1.25 }}
-          onClick={() =>
-            setInputFields((oldFields) => {
-              return { ...oldFields, words: "" } as InputFields;
-            })
-          }
+          onClick={() => goToPreviousStep()}
           className="text-lg flex items-center"
         >
           <div className="group hover:cursor-pointer flex items-center">

--- a/src/components/forms/resource-form/WordTextArea.tsx
+++ b/src/components/forms/resource-form/WordTextArea.tsx
@@ -5,10 +5,13 @@ import { useState } from "react";
 
 type Props = {
   setInputFields: React.Dispatch<React.SetStateAction<InputFields>>;
+  inputFields: InputFields;
+  goToPreviousStep: () => void;
+  goToNextStep: () => void;
 };
 
-export default function WordTextArea({ setInputFields }: Props) {
-  const [words, setWords] = useState<string>("");
+export default function WordTextArea({ setInputFields, inputFields, goToPreviousStep, goToNextStep }: Props) {
+  const [words, setWords] = useState<string>(inputFields.words || "");
 
   return (
     <div>
@@ -16,7 +19,7 @@ export default function WordTextArea({ setInputFields }: Props) {
         initial={{ opacity: 0, y: -100 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.75, delay: 1.25 }}
-        onClick={() => setInputFields({} as InputFields)}
+        onClick={() => goToPreviousStep()}
         className="text-lg flex items-center"
       >
         <div className="group hover:cursor-pointer flex items-center">
@@ -74,6 +77,7 @@ export default function WordTextArea({ setInputFields }: Props) {
                 ...oldFields,
                 words: words,
               }));
+              goToNextStep();
             }}
           >
             Continue


### PR DESCRIPTION
## Description
After the refactor in #26, the three pages (`LanguageSelector`, `WordTextArea`, and `ResourceSelector`) in the `ResourceForm` were maintaining their own individual state. The `inputFields` state value was used as the source of truth, and was _used to determine which step of the form the user was on_.

Clicking the "Continue" button on a page essentially committed the changes from the local state to the `inputFields` value. Having the value defined in `inputFields` indicated to the form that it should move to the next step. Going back in the form was achieved by clearing the part of `inputFields` that gets entered on the previous step of the form. The problem with this is that if, for example, the user selects their native and target languages, then enters a bunch of words, then clicks "Go back", then comes back to the words form, all of the words they entered will be gone. That state was lost when the `WordTextArea` component was unmounted.

This issue didn't exist before the refactor because all of the state was managed within `ResourceForm`, so even though the part of `inputFields` was cleared, the dedicated state for the field was still preserved. There weren't any children components being unmounted during the form flow.

To fix this, the `currentStep` state was added to keep track of which step of the form to show. The `inputFields` are the single source of truth, and are _not cleared when moving back to a previous step_.