### PR TITLE
[Fix] Update Github hook to remove old files before copying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/deployment
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
+    
+    - name: Clean EC2 app directory
+      run: |
+        ssh -o StrictHostKeyChecking=no ec2-user@54.152.37.238 'rm -rf /home/ec2-user/app/*'
 
     - name: Copy files to EC2
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/deployment
 
 jobs:
   deploy:


### PR DESCRIPTION
## Description
When the last PR was deployed, there was an issue building because it still had the old `ResourceForm.tsx` in the old location. I updated the Github Action to remove the previous files before copying over the new ones.