### PR TITLE
[Feat] Add a "Start over" button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "postcss": "^8.4.33",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
-        "vite": "^6.2.6",
+        "vite": "^6.3.4",
         "vitest": "^3.1.1",
         "vitest-fetch-mock": "^0.4.5"
       }
@@ -5120,6 +5120,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -5317,15 +5362,18 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
+      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5409,6 +5457,34 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
-    "vite": "^6.2.6",
+    "vite": "^6.3.4",
     "vitest": "^3.1.1",
     "vitest-fetch-mock": "^0.4.5"
   },

--- a/src/__tests__/App.spec.tsx
+++ b/src/__tests__/App.spec.tsx
@@ -1,15 +1,23 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import App from "../App";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "../store";
 
 describe("App.tsx", async () => {
+  beforeEach(() => {
+    window.scrollTo = vi.fn();
+  });
+
   it('Then should show "Anki Lingo" and blurb', async () => {
     // Act
     render(
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <Provider store={store}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </Provider>
     );
     // Assert
     const title = screen.queryAllByText("Anki Lingo");

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -6,7 +6,15 @@ import type { RootState } from "../store";
 import BackButton from "./BackButton";
 import { setDownloadUrl } from "../store/rootSlice";
 import formStyles from "./forms/shared.module.css";
-import { DELAY, EXIT, FADE_UP, HOVER, TRANSITION } from "../constants/animations";
+import {
+  DELAY,
+  EXIT,
+  FADE_UP,
+  HOVER,
+  TRANSITION,
+  TAP,
+} from "../constants/animations";
+import { resetFormState } from "./forms/utils/resetFormState";
 
 export default function Download() {
   const { downloadUrl, scrapedData } = useSelector(
@@ -68,22 +76,44 @@ export default function Download() {
             </div>
           </div>
         )}
-        <a
-          className="my-16"
-          href={downloadUrl}
-          download={`anki-lingo-${moment().format("YYYYMMDDHHmmss")}.zip`}
-        >
-          <motion.div
-            variants={FADE_UP}
-            initial="hidden"
-            animate="visible"
-            transition={TRANSITION.WITH_DELAY(DELAY.LONG)}
+        <div className="flex flex-row my-16">
+          <button onClick={() => resetFormState(dispatch)} className="mx-16">
+            <motion.div
+              variants={FADE_UP}
+              initial="hidden"
+              animate="visible"
+              transition={TRANSITION.WITH_DELAY(DELAY.LONG)}
+            >
+              <motion.button
+                className="button-destructive"
+                whileHover={HOVER.SCALE}
+                whileTap={TAP.SCALE}
+              >
+                Start Over
+              </motion.button>
+            </motion.div>
+          </button>
+          <a
+            className="mx-16"
+            href={downloadUrl}
+            download={`anki-lingo-${moment().format("YYYYMMDDHHmmss")}.zip`}
           >
-            <motion.button className="button" whileHover={HOVER.SCALE}>
-              Download
-            </motion.button>
-          </motion.div>
-        </a>
+            <motion.div
+              variants={FADE_UP}
+              initial="hidden"
+              animate="visible"
+              transition={TRANSITION.WITH_DELAY(DELAY.LONG)}
+            >
+              <motion.button
+                className="button"
+                whileHover={HOVER.SCALE}
+                whileTap={TAP.SCALE}
+              >
+                Download
+              </motion.button>
+            </motion.div>
+          </a>
+        </div>
       </div>
     </motion.div>
   );

--- a/src/components/forms/card-format-form/CardFormatForm.tsx
+++ b/src/components/forms/card-format-form/CardFormatForm.tsx
@@ -21,6 +21,7 @@ import {
   FADE_RIGHT,
   FADE_UP,
   HOVER,
+  TAP,
   TRANSITION,
 } from "../../../constants/animations";
 import {
@@ -248,6 +249,7 @@ export default function CardFormatForm() {
                       dispatch(setCardFormat({ sides: newSides }));
                     }}
                     whileHover={HOVER.SCALE}
+                    whileTap={TAP.SCALE}
                   >
                     <MdAddCircle size="48" color="#162e50" />
                   </motion.button>
@@ -270,6 +272,7 @@ export default function CardFormatForm() {
                       dispatch(setCardFormat({ sides: newSides }));
                     }}
                     whileHover={HOVER.SCALE}
+                    whileTap={TAP.SCALE}
                   >
                     <MdRemoveCircle size="48" color="#ad343e" />
                   </motion.button>
@@ -308,6 +311,7 @@ export default function CardFormatForm() {
           className="button"
           onClick={formatCSV}
           whileHover={HOVER.SCALE}
+          whileTap={TAP.SCALE}
         >
           Create CSV
         </motion.button>

--- a/src/components/forms/resource-form/LanguageSelector.tsx
+++ b/src/components/forms/resource-form/LanguageSelector.tsx
@@ -8,7 +8,15 @@ import {
   setNativeLanguage,
 } from "../../../store/resourceFormSlice";
 import formStyles from "../shared.module.css";
-import { DELAY, FADE_DOWN, FADE_RIGHT, FADE_UP, HOVER, TRANSITION } from "../../../constants/animations";
+import {
+  DELAY,
+  FADE_DOWN,
+  FADE_RIGHT,
+  FADE_UP,
+  HOVER,
+  TRANSITION,
+  TAP,
+} from "../../../constants/animations";
 
 type Props = {
   goToNextStep: () => void;
@@ -109,6 +117,13 @@ export default function LanguageSelector({ goToNextStep }: Props) {
               nativeLanguage === targetLanguage
                 ? undefined
                 : HOVER.SCALE
+            }
+            whileTap={
+              !nativeLanguage ||
+              !targetLanguage ||
+              nativeLanguage === targetLanguage
+                ? undefined
+                : TAP.SCALE
             }
             disabled={
               !nativeLanguage ||

--- a/src/components/forms/resource-form/ResourceSelector.tsx
+++ b/src/components/forms/resource-form/ResourceSelector.tsx
@@ -6,7 +6,15 @@ import { setIsLoading, setScrapedData } from "../../../store/rootSlice";
 import { RootState } from "../../../store";
 import { setLanguageResources } from "../../../store/resourceFormSlice";
 import formStyles from "../shared.module.css";
-import { DELAY, FADE_DOWN, FADE_RIGHT, FADE_UP, HOVER, TRANSITION } from "../../../constants/animations";
+import {
+  DELAY,
+  FADE_DOWN,
+  FADE_RIGHT,
+  FADE_UP,
+  HOVER,
+  TAP,
+  TRANSITION,
+} from "../../../constants/animations";
 
 export default function ResourceSelector() {
   const dispatch = useDispatch();
@@ -116,6 +124,11 @@ export default function ResourceSelector() {
                 !languageResources.some((resource) => resource.isSelected)
                   ? undefined
                   : HOVER.SCALE
+              }
+              whileTap={
+                !languageResources.some((resource) => resource.isSelected)
+                  ? undefined
+                  : TAP.SCALE
               }
               disabled={
                 !languageResources.some((resource) => resource.isSelected)

--- a/src/components/forms/resource-form/WordTextArea.tsx
+++ b/src/components/forms/resource-form/WordTextArea.tsx
@@ -9,6 +9,7 @@ import {
   FADE_DOWN,
   FADE_UP,
   HOVER,
+  TAP,
   TRANSITION,
 } from "../../../constants/animations";
 
@@ -68,6 +69,7 @@ export default function WordTextArea({ goToNextStep }: Props) {
           <motion.button
             className="button"
             whileHover={!textAreaValue ? undefined : HOVER.SCALE}
+            whileTap={!textAreaValue ? undefined : TAP.SCALE}
             disabled={!textAreaValue}
             onClick={() => {
               dispatch(setWords(textAreaValue));

--- a/src/components/forms/utils/__tests__/resetFormState.spec.ts
+++ b/src/components/forms/utils/__tests__/resetFormState.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { resetFormState } from "../resetFormState";
+
+describe("resetFormState.ts", () => {
+  it("Then dispatches reset actions for all fields", () => {
+    // Arrange
+    const mockDispatch = vi.fn();
+    // Act
+    resetFormState(mockDispatch);
+    // Assert
+    expect(mockDispatch).toHaveBeenCalledTimes(9);
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "resourceForm/setTargetLanguage",
+      payload: "",
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "resourceForm/setNativeLanguage",
+      payload: "",
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "resourceForm/setWords",
+      payload: "",
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "resourceForm/setLanguageResources",
+      payload: [],
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "root/setScrapedData",
+      payload: [],
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "root/setExportFields",
+      payload: [],
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "root/setCardFormat",
+      payload: { sides: [{ fields: ["inputWord"] }] },
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "root/setDownloadUrl",
+      payload: "",
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "root/setIsLoading",
+      payload: false,
+    });
+  });
+});

--- a/src/components/forms/utils/resetFormState.ts
+++ b/src/components/forms/utils/resetFormState.ts
@@ -1,0 +1,26 @@
+import type { Dispatch } from "redux";
+import {
+  setTargetLanguage,
+  setNativeLanguage,
+  setWords,
+  setLanguageResources,
+} from "../../../store/resourceFormSlice";
+import {
+  setScrapedData,
+  setExportFields,
+  setCardFormat,
+  setDownloadUrl,
+  setIsLoading,
+} from "../../../store/rootSlice";
+
+export function resetFormState(dispatch: Dispatch) {
+  dispatch(setTargetLanguage(""));
+  dispatch(setNativeLanguage(""));
+  dispatch(setWords(""));
+  dispatch(setLanguageResources([]));
+  dispatch(setScrapedData([]));
+  dispatch(setExportFields([]));
+  dispatch(setCardFormat({ sides: [{ fields: ["inputWord"] }] }));
+  dispatch(setDownloadUrl(""));
+  dispatch(setIsLoading(false));
+}

--- a/src/constants/animations.ts
+++ b/src/constants/animations.ts
@@ -54,6 +54,10 @@ export const HOVER = {
   SCALE: { scale: 1.05 },
 };
 
+export const TAP = {
+  SCALE: { scale: 0.98 },
+};
+
 export const EXIT = {
   DEFAULT: {
     opacity: 0,

--- a/src/index.css
+++ b/src/index.css
@@ -67,7 +67,19 @@ body {
   border-radius: 10px;
 }
 
+.button-destructive {
+  background-color: #ad343e;
+  color: #e3e5eb;
+  padding: 0.5rem 1.5rem;
+  font-size: large;
+  border-radius: 10px;
+}
+
 .button:hover {
+  cursor: pointer;
+}
+
+.button-destructive:hover {
   cursor: pointer;
 }
 

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,9 +1,25 @@
 import { Link } from "react-router-dom";
 import waves from "../assets/waves.svg";
 import { motion } from "framer-motion";
-import { DELAY, EXIT, FADE_UP, HOVER, TRANSITION } from "../constants/animations";
+import {
+  DELAY,
+  EXIT,
+  FADE_UP,
+  HOVER,
+  TRANSITION,
+  TAP,
+} from "../constants/animations";
+import { useEffect } from "react";
+import { resetFormState } from "../components/forms/utils/resetFormState";
+import { useDispatch } from "react-redux";
 
 export default function Landing() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    resetFormState(dispatch);
+  }, []);
+
   return (
     <motion.div
       className="route-component min-h-screen h-full relative flex flex-col justify-center items-center"
@@ -38,7 +54,11 @@ export default function Landing() {
             animate="visible"
             transition={TRANSITION.WITH_DELAY(DELAY.EXTRA_LONG)}
           >
-            <motion.div className="button mt-32 mb-12" whileHover={HOVER.SCALE}>
+            <motion.div
+              className="button mt-32 mb-12"
+              whileHover={HOVER.SCALE}
+              whileTap={TAP.SCALE}
+            >
               <div className="text-center">Get Started</div>
             </motion.div>
           </motion.div>

--- a/src/store/resourceFormSlice.ts
+++ b/src/store/resourceFormSlice.ts
@@ -9,14 +9,14 @@ const resourceFormSlice = createSlice({
     languageResources: [],
   } as InputFields,
   reducers: {
-    setWords: (state, action) => {
-      state.words = action.payload;
-    },
     setTargetLanguage: (state, action) => {
       state.targetLanguage = action.payload;
     },
     setNativeLanguage: (state, action) => {
       state.nativeLanguage = action.payload;
+    },
+    setWords: (state, action) => {
+      state.words = action.payload;
     },
     setLanguageResources: (state, action) => {
       state.languageResources = action.payload;
@@ -24,5 +24,10 @@ const resourceFormSlice = createSlice({
   },
 });
 
-export const { setWords, setTargetLanguage, setNativeLanguage, setLanguageResources } = resourceFormSlice.actions;
+export const {
+  setTargetLanguage,
+  setNativeLanguage,
+  setWords,
+  setLanguageResources,
+} = resourceFormSlice.actions;
 export default resourceFormSlice.reducer;

--- a/src/store/rootSlice.ts
+++ b/src/store/rootSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import type { CardFormat, CombinedScrapedResponse } from "../types/types";
+import type { CombinedScrapedResponse } from "../types/types";
 
 const slice = createSlice({
   name: "root",
@@ -9,7 +9,7 @@ const slice = createSlice({
     exportFields: [] as string[],
     cardFormat: {
       sides: [{ fields: ["inputWord"] }],
-    } as CardFormat,
+    },
     downloadUrl: "",
   },
   reducers: {
@@ -22,11 +22,11 @@ const slice = createSlice({
     setExportFields: (state, action) => {
       state.exportFields = action.payload;
     },
-    setDownloadUrl: (state, action) => {
-      state.downloadUrl = action.payload;
-    },
     setCardFormat: (state, action) => {
       state.cardFormat = action.payload;
+    },
+    setDownloadUrl: (state, action) => {
+      state.downloadUrl = action.payload;
     },
   },
 });
@@ -35,7 +35,7 @@ export const {
   setIsLoading,
   setScrapedData,
   setExportFields,
-  setDownloadUrl,
   setCardFormat,
+  setDownloadUrl,
 } = slice.actions;
 export default slice.reducer;


### PR DESCRIPTION
## Description
Adds a "Start over" button to the Download screen that allows the user to reset the form and fill it out again. The form is also cleared if they click the "Anki Lingo" text in the header.

Also adds functionality to make the buttons scale in on click to make them more visually responsive.

### Updated UI
<img width="1920" alt="Screenshot 2025-05-03 at 9 00 51 PM" src="https://github.com/user-attachments/assets/c96e1d12-4982-481f-893b-6ef7393255dc" />
