### PR TITLE
fix: bypass scraper blocking in Docker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Fullstack app that scrapes language-learning sites (WordReference, SpanishDict, Forvo, Michaelis BR, Semanticar BR, Larousse FR) to generate a CSV + audio bundle importable into Anki. React/TypeScript frontend, Flask/Python backend, BeautifulSoup scraping. Hosted at https://anki.taylorbarmak.com.
+
+## Commands
+
+Frontend (run from repo root):
+- `npm i` — install UI deps
+- `npm run dev` — start Vite dev server (proxies `/api` → `http://127.0.0.1:5000`)
+- `npm run build` — `tsc && vite build`
+- `npm run lint` — eslint, **zero warnings allowed** (`--max-warnings 0`)
+- `npm test` — vitest (jsdom env)
+- single test: `npx vitest run src/path/to/file.spec.ts` or `npx vitest -t "test name"`
+
+Backend (Python venv lives at `api/env`):
+- setup: `cd api && python -m venv env && source env/bin/activate && pip install -r requirements.txt`
+- `npm run start-api` — runs `cd api && env/bin/flask run --no-debugger` (port 5000)
+- `npm run test-api` — runs `api/env/bin/pytest` (full suite)
+- single test: `api/env/bin/pytest api/scrapers/tests/test_word_reference.py`
+
+Docker: `docker-compose up` → UI at `localhost:8080`. Note some sites block traffic from the Docker network.
+
+## Architecture
+
+### Request flow (frontend → backend → CSV)
+1. **ResourceForm** (`src/components/forms/resource-form/`) — user picks native/target language and words. On language select, frontend fetches `api/resources/<language>` for available resources, then pings each resource's `healthRoute` to show green/red health dots.
+2. **getFlashcardData** (`src/components/forms/utils/getFlashcardData.ts`) — fan-out scraper. For each word × each selected resource, builds the URL by joining `resource.route` with `resource.args` mapped through `{word, targetLang, nativeLang}`, fetches, and merges all results per word into a `CombinedScrapedResponse` (collecting `urls` and per-resource `errors`). A failed resource degrades gracefully (recorded in `errors`, not thrown).
+3. **CardFormatForm** (`src/components/forms/card-format-form/`) — drag-and-drop (`@dnd-kit`) UI to assign fields to card sides. Produces a `cardFormat` = `{ sides: [{ fields: [...] }] }`.
+4. **Download** — POSTs `{ scrapedData, cardFormat }` to `api/format-csv`, gets back a zip, downloads as `anki-lingo-<timestamp>.zip`.
+
+`src/pages/Main.tsx` is a state machine driven by Redux: `isLoading` → Loading, `downloadUrl` → Download, `scrapedData.length` → CardFormatForm, else ResourceForm. Global state in `src/store/rootSlice.ts` (Redux Toolkit): `scrapedData`, `cardFormat`, `exportFields`, `downloadUrl`, `isLoading`.
+
+### Backend (`api/api.py`)
+`create_app()` defines all routes. Two driving constants:
+- **`LANGUAGE_RESOURCES`** — the source of truth for what the frontend sees. Each entry's `route`, `args`, `outputs`, `supportedLanguages`, `healthRoute` flow to the UI via `api/resources/<language>`.
+- **`FLASHCARD_FIELDS`** — maps internal field keys to display labels (`api/field-mapping`).
+
+Each scraper has one route (e.g. `api/wr/<target>/<native>/<word>`) returning `{inputWord, scrapedWordData, url}, status_code`. `api/format-csv` (POST) writes audio `.ogg` files from `api/audio_files/` plus an `anki.csv` into a zip under `api/zip_files/` (named by sha256 of the request), then `send_file`s it.
+
+### Scrapers (`api/scrapers/`)
+Each module exposes `scrape_<site>(...)` returning `(list_of_entry_dicts, url, status_code)`. Entry dicts use a subset of these keys (the shared field contract across frontend types, scrapers, and CSV formatting):
+`word, pos, definition, translations[], targetExampleSentences[], nativeExampleSentences[], audioFilenames[], expression, expressionMeaning`.
+`template.py` is the starting skeleton. Scrapers set browser-like `HEADERS` to avoid 403s (see `word_reference.py`).
+
+### CSV formatting (`api/utils/format_csv.py`)
+Turns scraped entries + `cardFormat` into pipe-delimited rows.
+- `create_csv_sides` — front side is the input word; `cardFormat.sides[1:]` become the back sides. Source `urls` are appended (as clickable `<a>` links) to the first back side.
+- `restructure_scraped_dict` — groups entries by `word`/`pos` if those fields are on the side.
+- `format_entry` — orders fields by `FIELD_PRIORITY_RANKING`, joins with `<br>`, wraps audio as `[sound:filename]` and translations as comma-joined.
+- Output is `|`-separated columns, `\n`-separated rows → **Anki import uses Pipe separator + Allow HTML on**.
+
+## Scraper tests (snapshot-based)
+Sites are dynamic, so scrapers are tested against frozen HTML snapshots in `api/scrapers/tests/mocks/`, mocked via `requests_mock`, asserting against expected JSON in the `expected_outputs/` folder. See `docs/Testing.md` for the workflow to create/refresh mocks and expected outputs. The health-check routes in `LANGUAGE_RESOURCES` are the live signal that a site's structure changed and broke a scraper.
+
+## Adding a new scraper
+Full steps in `docs/CreatingNewScrapingEndpoint.md`. Summary: copy `template.py`, implement `create_url`/parsing returning the entry-dict contract above, add a route in `api.py`, append an entry to `LANGUAGE_RESOURCES`, then add a snapshot test.

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ python-dotenv==1.1.0
 Werkzeug==3.1.3
 beautifulsoup4==4.13.3
 requests==2.32.3
+curl_cffi==0.13.0
 pytest==8.3.5
 coverage==7.8.0
 requests-mock==1.12.1

--- a/api/scrapers/forvo.py
+++ b/api/scrapers/forvo.py
@@ -12,8 +12,6 @@ LANGUAGE_TO_ABBV = {
     "italiano": "it"
 }
 
-# Forvo blocks the default TLS fingerprint of the container's OpenSSL build, so
-# all Forvo requests use curl_cffi browser impersonation (impersonate=True).
 FORVO_HEADERS = {
     "Referer": "https://www.google.com/",
     "Upgrade-Insecure-Requests": "1",

--- a/api/scrapers/forvo.py
+++ b/api/scrapers/forvo.py
@@ -1,8 +1,7 @@
 from bs4 import BeautifulSoup
 import base64
-import urllib.request
 import urllib.parse
-import requests
+from api.scrapers.http_client import fetch
 
 # TODO: Give the user the option to pick the accent they want
 LANGUAGE_TO_ABBV = {
@@ -13,13 +12,11 @@ LANGUAGE_TO_ABBV = {
     "italiano": "it"
 }
 
-headers = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:77.0) Gecko/20100101 Firefox/77.0",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+# Forvo blocks the default TLS fingerprint of the container's OpenSSL build, so
+# all Forvo requests use curl_cffi browser impersonation (impersonate=True).
+FORVO_HEADERS = {
     "Referer": "https://www.google.com/",
-    "Accept-Language": "en-US,en;q=0.5",
-    "Connection": "keep-alive",
-    "Upgrade-Insecure-Requests": "1"
+    "Upgrade-Insecure-Requests": "1",
 }
 
 
@@ -50,30 +47,27 @@ def get_top_pronunciation_url(table):
 
 
 def download_audio(url: str, word: str, lang_abbv: str):
-    url_request = urllib.request.Request(
-        url, headers=headers)
-    response = urllib.request.urlopen(url_request)
+    response = fetch(url, headers=FORVO_HEADERS, impersonate=True)
     output_filename = f"pronunciation_{lang_abbv}_{'_'.join(word.split())}.ogg"
     with open("audio_files/" + output_filename, "b+w") as fh:
-        fh.write(response.read())
+        fh.write(response.content)
     return output_filename
 
 
 def scrape_forvo(word: str, language: str):
     lang_abbv = LANGUAGE_TO_ABBV[language.lower()]
     url = create_url(word, lang_abbv)
-    url_request = urllib.request.Request(
-        url, headers=headers)
     try:
-        response = urllib.request.urlopen(url_request)
-        content = response.read()
-        soup = BeautifulSoup(content, "html.parser")
+        response = fetch(url, headers=FORVO_HEADERS, impersonate=True)
+    except Exception:
+        return [], url, 500
+    if not response.ok:
+        return [], url, response.status_code
+    try:
+        soup = BeautifulSoup(response.content, "html.parser")
         table = get_table(soup, lang_abbv)
         pronunciation_url = get_top_pronunciation_url(table)
         output_filename = download_audio(pronunciation_url, word, lang_abbv)
-        return [{"audioFilenames": [output_filename]}], url, response.getcode()
-    except urllib.error.HTTPError as e:
-        return [], url, e.code
-    except urllib.error.URLError as e:
-        return [], url, 500
-    
+        return [{"audioFilenames": [output_filename]}], url, response.status_code
+    except Exception:
+        return [], url, response.status_code

--- a/api/scrapers/http_client.py
+++ b/api/scrapers/http_client.py
@@ -1,0 +1,62 @@
+"""Shared HTTP client for all scrapers.
+
+Centralizes browser-like headers and timeouts so every scraper looks like a
+real browser instead of the default ``python-requests`` user agent.
+
+Two modes:
+  * default (``impersonate=False``) uses the ``requests`` library. This keeps
+    the scrapers' existing ``requests_mock``-based tests working.
+  * ``impersonate=True`` uses ``curl_cffi`` to mimic a real browser's TLS
+    handshake (JA3/JA4 fingerprint). Some sites (e.g. Forvo) block based on the
+    TLS fingerprint of the container's OpenSSL build, which a User-Agent header
+    alone cannot defeat.
+
+Both backends return a response object exposing ``.status_code``, ``.ok``,
+``.text`` and ``.content``, so scraper logic does not need to branch.
+"""
+
+import requests
+
+BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.5",
+    "Connection": "keep-alive",
+}
+
+DEFAULT_TIMEOUT = 20
+
+
+def fetch(url, headers=None, timeout=DEFAULT_TIMEOUT, impersonate=False):
+    """Perform a GET request with browser-like headers.
+
+    Parameters
+    ------------
+        url: str
+            The URL to fetch.
+        headers: dict | None
+            Extra headers merged on top of BROWSER_HEADERS.
+        timeout: int
+            Request timeout in seconds.
+        impersonate: bool
+            When True, use curl_cffi with browser TLS impersonation to bypass
+            TLS-fingerprint-based blocking.
+
+    Return
+    ------------
+        A response object with .status_code, .ok, .text and .content.
+    """
+    merged_headers = {**BROWSER_HEADERS, **(headers or {})}
+    if impersonate:
+        from curl_cffi import requests as cffi_requests
+
+        return cffi_requests.get(
+            url, headers=merged_headers, timeout=timeout, impersonate="chrome"
+        )
+    return requests.get(url, headers=merged_headers, timeout=timeout)

--- a/api/scrapers/larouse_fr.py
+++ b/api/scrapers/larouse_fr.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup, NavigableString
-import requests
 from urllib.parse import quote
+from api.scrapers.http_client import fetch
 
 
 def create_url(word):
@@ -27,7 +27,7 @@ def parse_soup(soup):
 
 def scrape_larouse(word):
     url = create_url(word)
-    response = requests.get(url)
+    response = fetch(url)
     if response.ok:
         soup = BeautifulSoup(response.text, "html.parser")
         return parse_soup(soup), url, response.status_code

--- a/api/scrapers/michaelis_br.py
+++ b/api/scrapers/michaelis_br.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
-import requests
 from urllib.parse import quote
+from api.scrapers.http_client import fetch
 
 
 def create_url(word):
@@ -98,7 +98,7 @@ def parse_rows(rows):
 
 def scrape_michaelis(word):
     url = create_url(word)
-    response = requests.get(url)
+    response = fetch(url)
     if response.ok:
         soup = BeautifulSoup(response.text, "html.parser")
         container = soup.find("div", {"class": "verbete bs-component"})

--- a/api/scrapers/semanticar_br.py
+++ b/api/scrapers/semanticar_br.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
-import requests
 from urllib.parse import quote
 import json
+from api.scrapers.http_client import fetch
 
 
 def create_url(word):
@@ -21,7 +21,7 @@ def get_sentences_and_definitions(word, soup):
 
 def scrape_semanticar(word):
     url = create_url(word)
-    response = requests.get(url)
+    response = fetch(url)
     if response.ok:
         soup = BeautifulSoup(response.text, "html.parser")
         scraped_data = get_sentences_and_definitions(word, soup)

--- a/api/scrapers/spanishdict.py
+++ b/api/scrapers/spanishdict.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
-import requests
 from urllib.parse import quote
+from api.scrapers.http_client import fetch
 
 LANGUAGE_TO_ABBV = {
     "english": "en",
@@ -144,7 +144,7 @@ def scrape_spanishdict(word, target_lang):
     '''
     target_lang_abbv = LANGUAGE_TO_ABBV[target_lang.lower()]
     url = create_url(word, target_lang_abbv)
-    response = requests.get(url)
+    response = fetch(url)
     if response.ok:
         soup = BeautifulSoup(response.text, "html.parser")
         meanings_container = soup.find(

--- a/api/scrapers/tests/test_forvo.py
+++ b/api/scrapers/tests/test_forvo.py
@@ -40,9 +40,6 @@ class TestForvo:
         word = "avoir"
         language = "français"
         mock_response = get_mock_response(get_mock_response_filename(word, "fr"))
-        # fetch is called twice (page, then audio); a single response object
-        # serves both: .content for the page HTML and (irrelevant) bytes for
-        # the mocked audio file write.
         mock_resp = MagicMock()
         mock_resp.content = mock_response.encode("UTF-8")
         mock_resp.ok = True

--- a/api/scrapers/tests/test_forvo.py
+++ b/api/scrapers/tests/test_forvo.py
@@ -1,7 +1,6 @@
 from api.scrapers.forvo import create_url, scrape_forvo
 from unittest.mock import patch, mock_open, MagicMock
 from api.scrapers.tests.utils.get_mock_response import get_mock_response
-from urllib.error import HTTPError
 
 def get_mock_response_filename(word, lang_abbv):
     return f"forvo_{word}_{lang_abbv}.html"
@@ -35,15 +34,20 @@ class TestForvo:
         # Assert
         assert url == "https://forvo.com/word/ba%C3%AEller/#fr"
 
-    @patch("urllib.request.urlopen")
-    def test_scrape_forvo_avoir(self, mock_urlopen):
+    @patch("api.scrapers.forvo.fetch")
+    def test_scrape_forvo_avoir(self, mock_fetch):
         # Arrange
         word = "avoir"
         language = "français"
         mock_response = get_mock_response(get_mock_response_filename(word, "fr"))
-        mock_urlopen.return_value.read.return_value = mock_response.encode(
-            "UTF-8")
-        mock_urlopen.return_value.getcode.return_value = 200
+        # fetch is called twice (page, then audio); a single response object
+        # serves both: .content for the page HTML and (irrelevant) bytes for
+        # the mocked audio file write.
+        mock_resp = MagicMock()
+        mock_resp.content = mock_response.encode("UTF-8")
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_fetch.return_value = mock_resp
         mock_file_open = mock_open()
         # Act
         with patch("builtins.open", mock_file_open, create=True):
@@ -53,21 +57,18 @@ class TestForvo:
             "audio_files/pronunciation_fr_avoir.ogg", "b+w")
         assert audio_filenames == [
             {"audioFilenames": ["pronunciation_fr_avoir.ogg"]}]
-        assert url == create_url(word, "fr") 
+        assert url == create_url(word, "fr")
         assert status_code == 200
 
-    @patch("urllib.request.urlopen")
-    def test_scrape_forvo_unauthorized(self, mock_urlopen):
+    @patch("api.scrapers.forvo.fetch")
+    def test_scrape_forvo_unauthorized(self, mock_fetch):
         # Arrange
         word = "avoir"
         language = "français"
-        mock_urlopen.side_effect = HTTPError(
-            url="https://forvo.com",
-            code=403,
-            msg="Forbidden",
-            hdrs=None,
-            fp=None
-        )
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 403
+        mock_fetch.return_value = mock_resp
         # Act
         audio_filenames, url, status_code = scrape_forvo(word, language)
         # Assert

--- a/api/scrapers/word_reference.py
+++ b/api/scrapers/word_reference.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
-import requests
 from urllib.parse import quote
+from api.scrapers.http_client import fetch
 
 LANGUAGE_TO_ABBV = {
     "english": "en",
@@ -65,14 +65,6 @@ def parse_first_table(table):
     return entries
 
 
-HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-    "Accept-Language": "en-US,en;q=0.5",
-    "Connection": "keep-alive",
-}
-
-
 def scrape_word_reference(word, target_lang, native_lang):
     native_lang_abbv = LANGUAGE_TO_ABBV.get(native_lang.lower())
     target_lang_abbv = LANGUAGE_TO_ABBV.get(target_lang.lower())
@@ -80,7 +72,7 @@ def scrape_word_reference(word, target_lang, native_lang):
         return [], "", 400
 
     url = create_url(word, target_lang_abbv, native_lang_abbv)
-    response = requests.get(url, headers=HEADERS)
+    response = fetch(url)
     if response.ok:
         soup = BeautifulSoup(response.text, "html.parser")
         tables = soup.find_all("table", {"class": "WRD"})


### PR DESCRIPTION
## Problem
Scrapers worked on the macOS host (`npm run start-api`) but several failed under Docker (local `:8080` and the public deploy at anki.taylorbarmak.com). Health dots showed sites as blocked.

## Root causes (confirmed empirically against the running container)
Host and container exit the **same public IP**, so it is not IP reputation. Two causes:

1. **Fragile default User-Agent** — `spanishdict`, `michaelis_br`, `semanticar_br`, `larouse_fr` sent the default `python-requests` UA. WordReference proved a site can flip to 403 on it at any time.
2. **Forvo TLS-fingerprint block** — same code/headers/IP: host → 200, container `requests` and `curl` → 403. The Debian image's older OpenSSL TLS handshake is fingerprinted and blocked; a browser User-Agent alone cannot fix it.

## Changes
- New `api/scrapers/http_client.py` with a shared `fetch()`: browser headers + 20s timeout. Defaults to the `requests` library (so `requests_mock` tests still work) and switches to `curl_cffi` browser TLS impersonation when `impersonate=True`.
- All six scrapers routed through `fetch`. Forvo rewritten off `urllib` to `fetch(impersonate=True)` for both the page and the audio download, with status-code-based error handling.
- `curl_cffi==0.13.0` added to `requirements.txt` (installs clean on the `python:3.9` base, no extra system libs).
- `test_forvo.py` repointed to mock `fetch`.
- Add `CLAUDE.md` documenting commands and architecture.

## Verification
- `npm run test-api` → **76 passed**.
- `docker compose build --no-cache api` builds clean.
- All six health routes return **200 with data** through `:8080` (previously WR 403, Forvo 403, Semanticar 500):

| Route | Before | After |
|---|---|---|
| WordReference | 403 | 200 |
| SpanishDict | 200 | 200 |
| Michaelis BR | 200 | 200 |
| Forvo | 403 | 200 |
| Semanticar BR | 500 | 200 |
| Larousse FR | 200 | 200 |

## Deploy note
Redeploy must rebuild the image (`eb deploy`). Locally, use `docker compose build --no-cache api` — plain `docker compose up` reuses the stale image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)