### PR TITLE
feat: replace loading spinner with word-fetch progress bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
-        "react-loader-spinner": "^6.1.6",
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.30.0"
       },
@@ -291,11 +290,6 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true,
       "peer": true
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.2",
@@ -1744,11 +1738,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw=="
-    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -2364,14 +2353,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001713",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
@@ -2533,24 +2514,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -3946,6 +3909,7 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
       "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4160,6 +4124,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -4335,7 +4300,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -4445,27 +4411,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "node_modules/react-loader-spinner": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-6.1.6.tgz",
-      "integrity": "sha512-x5h1Jcit7Qn03MuKlrWcMG9o12cp9SNDVHVJTNRi9TgtGPKcjKiXkou4NRfLAtXaFB3+Z8yZsVzONmPzhv2ErA==",
-      "dependencies": {
-        "react-is": "^18.2.0",
-        "styled-components": "^6.1.2"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-redux": {
@@ -4720,11 +4665,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4769,6 +4709,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4890,88 +4831,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/styled-components": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.8.tgz",
-      "integrity": "sha512-PQ6Dn+QxlWyEGCKDS71NGsXoVLKfE1c3vApkvDYS5KAK+V8fNWGhbSUEo9Gg2iaID2tjLXegEW3bZDUGpofRWw==",
-      "dependencies": {
-        "@emotion/is-prop-valid": "1.2.1",
-        "@emotion/unitless": "0.8.0",
-        "@types/stylis": "4.2.0",
-        "css-to-react-native": "3.2.0",
-        "csstype": "3.1.2",
-        "postcss": "8.4.31",
-        "shallowequal": "1.1.0",
-        "stylis": "4.3.1",
-        "tslib": "2.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
-      }
-    },
-    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.1"
-      }
-    },
-    "node_modules/styled-components/node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
-    },
-    "node_modules/styled-components/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
-    },
-    "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/styled-components/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
-    "node_modules/stylis": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.1.tgz",
-      "integrity": "sha512-EQepAV+wMsIaGVGX1RECzgrcqRRU/0sYOHkeLsZ3fzHaHXZy4DaOOX0vOlGQdlsjkh3mFHAIlVimpwAs4dslyQ=="
     },
     "node_modules/sucrase": {
       "version": "3.35.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
-    "react-loader-spinner": "^6.1.6",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.30.0"
   },

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,8 +1,14 @@
-import { Bars } from "react-loader-spinner";
 import { motion } from "framer-motion";
+import { useSelector } from "react-redux";
+import { RootState } from "../store";
 import { FADE, EXIT, TRANSITION } from "../constants/animations";
 
 export default function Loading() {
+  const { current, total } = useSelector(
+    (state: RootState) => state.root.wordProgress
+  );
+  const percent = total > 0 ? Math.round((current / total) * 100) : 0;
+
   return (
     <motion.div
       variants={{
@@ -15,10 +21,17 @@ export default function Loading() {
       transition={TRANSITION.DEFAULT}
       className="w-full h-full flex flex-col justify-center items-center"
     >
-      <div className="my-4">
-        <Bars height="60" width="60" color="#162e50" />
+      <div className="my-4 w-64 h-3 rounded-full bg-gray-300 overflow-hidden">
+        <motion.div
+          className="h-full secondary-background rounded-full"
+          initial={{ width: 0 }}
+          animate={{ width: `${percent}%` }}
+          transition={TRANSITION.DEFAULT}
+        />
       </div>
-      <p className="text-xl secondary-text">Creating your flashcards...</p>
+      <p className="text-xl secondary-text">
+        Creating your flashcards... {current} of {total} words/phrases
+      </p>
     </motion.div>
   );
 }

--- a/src/components/forms/resource-form/ResourceSelector.tsx
+++ b/src/components/forms/resource-form/ResourceSelector.tsx
@@ -2,7 +2,11 @@ import { motion } from "framer-motion";
 import { getFlashcardData } from "../utils/getFlashcardData";
 import { MdCheckBox, MdCheckBoxOutlineBlank } from "react-icons/md";
 import { useDispatch, useSelector } from "react-redux";
-import { setIsLoading, setScrapedData } from "../../../store/rootSlice";
+import {
+  setWordProgress,
+  setIsLoading,
+  setScrapedData,
+} from "../../../store/rootSlice";
 import { RootState } from "../../../store";
 import { setLanguageResources } from "../../../store/resourceFormSlice";
 import formStyles from "../shared.module.css";
@@ -35,13 +39,22 @@ export default function ResourceSelector() {
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    const totalWords = words.trim() === "" ? 0 : words.split("\n").length;
+    dispatch(setWordProgress({ current: 0, total: totalWords }));
     dispatch(setIsLoading(true));
-    getFlashcardData({
-      words,
-      targetLanguage,
-      nativeLanguage,
-      languageResources,
-    }).then((res) => {
+    let completedWords = 0;
+    getFlashcardData(
+      {
+        words,
+        targetLanguage,
+        nativeLanguage,
+        languageResources,
+      },
+      () => {
+        completedWords += 1;
+        dispatch(setWordProgress({ current: completedWords, total: totalWords }));
+      }
+    ).then((res) => {
       dispatch(setScrapedData(res));
       dispatch(setIsLoading(false));
     });

--- a/src/components/forms/utils/getFlashcardData.ts
+++ b/src/components/forms/utils/getFlashcardData.ts
@@ -7,7 +7,8 @@ import {
 } from "../../../types/types";
 
 export function getFlashcardData(
-  inputFields: InputFields
+  inputFields: InputFields,
+  onWordDone?: () => void
 ): Promise<CombinedScrapedResponse[]> {
   // Return an empty list if no words are passed
   if (inputFields.words.trim() === "") {
@@ -69,6 +70,7 @@ export function getFlashcardData(
             .filter((res) => res.error)
             .map((res) => res.error as string),
         });
+        onWordDone?.();
       });
     });
   });

--- a/src/store/rootSlice.ts
+++ b/src/store/rootSlice.ts
@@ -5,6 +5,7 @@ const slice = createSlice({
   name: "root",
   initialState: {
     isLoading: false,
+    wordProgress: { current: 0, total: 0 },
     scrapedData: [] as CombinedScrapedResponse[],
     exportFields: [] as string[],
     cardFormat: {
@@ -15,6 +16,9 @@ const slice = createSlice({
   reducers: {
     setIsLoading: (state, action) => {
       state.isLoading = action.payload;
+    },
+    setWordProgress: (state, action) => {
+      state.wordProgress = action.payload;
     },
     setScrapedData: (state, action) => {
       state.scrapedData = action.payload;
@@ -33,6 +37,7 @@ const slice = createSlice({
 
 export const {
   setIsLoading,
+  setWordProgress,
   setScrapedData,
   setExportFields,
   setCardFormat,


### PR DESCRIPTION
## Summary
Replaces the indeterminate loading spinner with a determinate progress bar that tracks word-fetch completion.

- `Loading` now reads `wordProgress` from Redux and renders an animated bar plus `Creating your flashcards... {current} of {total} words/phrases`
- `getFlashcardData` accepts an optional `onWordDone` callback, fired as each word finishes
- `ResourceSelector` seeds the total, increments completed count per word, and dispatches `setWordProgress`
- New `wordProgress` state + `setWordProgress` reducer in `rootSlice`
- Drops the `react-loader-spinner` dependency (and its transitive `styled-components` tree)

### UI Changes
**Before**
<img width="1728" height="1117" alt="Screenshot 2026-06-19 at 5 36 52 PM" src="https://github.com/user-attachments/assets/100ef66d-06d8-482b-8a85-4f81070b515a" />


**After**
<img width="1728" height="1117" alt="Screenshot 2026-06-19 at 5 36 18 PM" src="https://github.com/user-attachments/assets/2bd53172-8301-4022-8972-dbcc999c1070" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
