### PR TITLE
fix: reduce clickable area of 'Get Started' button

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -47,22 +47,23 @@ export default function Landing() {
         >
           Automate generating Anki flashcards for learning foreign languages.
         </motion.p>
-        <Link to="/home">
-          <motion.div
-            variants={FADE_UP}
-            initial="hidden"
-            animate="visible"
-            transition={TRANSITION.WITH_DELAY(DELAY.EXTRA_LONG)}
-          >
+        <motion.div
+          variants={FADE_UP}
+          initial="hidden"
+          animate="visible"
+          transition={TRANSITION.WITH_DELAY(DELAY.EXTRA_LONG)}
+          className="mt-32 mb-12"
+        >
+          <Link to="/home">
             <motion.div
-              className="button mt-32 mb-12"
+              className="button"
               whileHover={HOVER.SCALE}
               whileTap={TAP.SCALE}
             >
               <div className="text-center">Get Started</div>
             </motion.div>
-          </motion.div>
-        </Link>
+          </Link>
+        </motion.div>
       </div>
       <motion.div
         variants={FADE_UP}


### PR DESCRIPTION
## Description
Having the margin specified inside the Link was causing the Link to be clickable well above (and a little below) where the button appeared. This issue is fixed by rearranging the hierarchy of the animated components.

**Before**
<img width="1728" height="1117" alt="Screenshot 2026-06-19 at 7 13 37 PM" src="https://github.com/user-attachments/assets/6e431ce9-3c9a-4904-8ce3-12148d7ab7b9" />

**After**
<img width="1728" height="1117" alt="Screenshot 2026-06-19 at 7 13 56 PM" src="https://github.com/user-attachments/assets/f4c82243-7dad-4d8a-8e80-22a33cb165d7" />

