### PR TITLE
ci: add lint, build, and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend (lint, build, test)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Lint
+      run: npm run lint
+
+    - name: Build
+      run: npm run build
+
+    - name: Test
+      run: npx vitest run
+
+  backend:
+    name: Backend (pytest)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: pip
+        cache-dependency-path: api/requirements.txt
+
+    - name: Install dependencies
+      run: pip install -r api/requirements.txt
+
+    - name: Test
+      run: pytest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/cleanup-old-zips
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

Adds a CI workflow so PRs into `main` are gated on lint, build, and tests. Currently nothing checks a PR before merge. The only workflow in the repo is `deploy.yml`, which fires *after* a merge lands on `main`.

Also removes a stale branch from the deploy trigger.

## What's here

**`ci.yml` (new)** — runs on `pull_request → main` and `push → main`:

| Job | Steps |
|---|---|
| Frontend | `npm ci`, `npm run lint`, `npm run build`, `npx vitest run` |
| Backend | `pip install -r api/requirements.txt`, `pytest` |

- Two parallel jobs, so a backend failure doesn't mask a frontend one.
- `permissions: contents: read` — the job token can't write to the repo.
- `concurrency` with `cancel-in-progress`, so re-pushing a PR cancels the stale run.
- `npx vitest run` rather than `npm test`: the `test` script is bare `vitest`, which is watch mode and would hang the runner.
- `pytest` runs from the repo root, since the tests import `api.scrapers.*` and `api/__init__.py` makes it a package.

**`deploy.yml`** — drops `feat/cleanup-old-zips` from the push trigger. That branch is unprotected, so a push to it deployed straight to prod, bypassing the PR flow entirely.

## Verified locally

| Step | Result |
|---|---|
| `npm run lint` | clean, 0 warnings |
| `npm run build` | success |
| `npx vitest run` | 10 passed (3 files) |
| `pytest` | 78 passed |

## Follow-up

Once this merges and the checks have run on `main` once, add `Frontend (lint, build, test)` and `Backend (pytest)` as required status checks on the `main` ruleset — GitHub can't offer the check names until it has seen them run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)