### PR TITLE
fix: make EC2 deploy safe to fail and re-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '22'
         cache: npm
@@ -48,10 +48,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
         cache: pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Set up SSH
       uses: webfactory/ssh-agent@v0.7.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# Deploys queue rather than overlap. cancel-in-progress is deliberately false:
+# killing a deploy mid-swap would leave the app directory half-populated.
+concurrency:
+  group: deploy-ec2
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,20 +23,25 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
-    
-    - name: Clean EC2 app directory
-      run: |
-        ssh -o StrictHostKeyChecking=no ec2-user@54.152.37.238 'rm -rf /home/ec2-user/app/*'
 
-    - name: Copy files to EC2
+    # Upload into a staging directory first. If this fails, the running app is
+    # untouched — the old code keeps serving until a later deploy succeeds.
+    - name: Upload files to EC2 staging directory
       run: |
-        scp -o StrictHostKeyChecking=no -r * ec2-user@54.152.37.238:/home/ec2-user/app
-    
+        ssh -o StrictHostKeyChecking=no ec2-user@54.152.37.238 'rm -rf /home/ec2-user/app.new && mkdir -p /home/ec2-user/app.new'
+        scp -o StrictHostKeyChecking=no -r * ec2-user@54.152.37.238:/home/ec2-user/app.new
+
     - name: SSH into EC2 and deploy
       run: |
-        ssh -o StrictHostKeyChecking=no ec2-user@54.152.37.238 << EOF
+        ssh -o StrictHostKeyChecking=no ec2-user@54.152.37.238 << 'EOF'
+          set -e
+          if [ -d /home/ec2-user/app ]; then
+            cd /home/ec2-user/app
+            docker-compose down
+          fi
+          rm -rf /home/ec2-user/app
+          mv /home/ec2-user/app.new /home/ec2-user/app
           cd /home/ec2-user/app
-          docker-compose down
-          docker system prune -f --volumes
           docker-compose up -d --build
+          docker image prune -f
         EOF


### PR DESCRIPTION
## Summary

Reliability fixes to the deploy workflow, plus an Actions version bump that has a deadline attached to it.

## Reliability fixes

**Delete-before-copy could leave the deploy unrecoverable.** The old flow ran `rm -rf /home/ec2-user/app/*` and *then* `scp`. Any failure in between — network blip, disk full — emptied the app directory, taking `docker-compose.yml` with it. The site kept serving, since the containers run from images rather than the host directory, but the stack was no longer manageable: no `down`, no `up`, no restart, and any container restart or instance reboot would have left it dead with no recovery except re-running the job. Files now upload to `app.new` first; `app` is only touched once the upload has succeeded, and the swap is a local `rm -rf` + `mv`.

**Volume pruning is broader than this deploy needs.** `docker system prune -f --volumes` removes unused volumes alongside images. That's harmless while the app holds no persistent state, but it ties deploy-time cleanup to an assumption we'd have to remember to revisit the day we add a database or a cache. Narrowed to `docker image prune -f`, which reclaims the disk that actually accumulates, and moved to after `up --build` so it clears the images this deploy superseded rather than ones the build is about to reuse. `docker system prune` drops build cache along with dangling images, so running it immediately before `--build` forced a cold rebuild — `npm install`, `vite build`, and pip install from scratch — on every single deploy.

**Two merges could race.** Added `concurrency: deploy-ec2`. `cancel-in-progress` is deliberately `false` — killing a deploy mid-swap would leave the app directory half-populated.

Two supporting changes: `set -e` in the remote script, so a failed command fails the job instead of charging ahead (it didn't before), and `docker-compose down` is now guarded behind `[ -d /home/ec2-user/app ]` so the first run after this change doesn't fail on a missing directory.

## Not addressed

`--build` still runs on the `up`, inside the `down`/`up` window, so the host nginx has nothing on `127.0.0.1:8080` and returns 502 for the duration of the image build. This PR shortens that window by letting the build keep its cache, but doesn't close it. Closing it means running `docker-compose build` from the staging directory *before* tearing the old containers down.

## Action versions

| Action | Before | After | Why |
|---|---|---|---|
| `actions/checkout` (deploy) | v3 | v7 | **v3 declares the node16 runtime**, deprecated on GitHub runners. Breaks deploys on a date we don't control |
| `actions/checkout` (ci) | v4 | v7 | node20, not urgent — bundled for consistency |
| `actions/setup-node` (ci) | v4 | v7 | same |
| `actions/setup-python` (ci) | v5 | v7 | same |
| `webfactory/ssh-agent` | v0.7.0 | v0.7.0 | **unchanged** — pre-1.0 third-party action holding the deploy key. Not worth bumping without reading the diff |

Every input passed to `setup-node` and `setup-python` still exists in v7 (verified against each action's `action.yml` at that ref). The `checkout` usage is bare, no `with:` block, so nothing depends on cross-major behavior.

## Testing

`ci.yml` changes are exercised by this PR's own checks.

`deploy.yml` cannot be tested before merge — it needs the EC2 host. Verified what's verifiable locally: the YAML parses and the remote script passes `bash -n`. **First real test is the merge to main**, so worth watching that run.

Note the compose project name stays `app`, because the final directory name is unchanged. A per-release directory scheme would have renamed the project and orphaned the running containers on port 8080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

