### PR TITLE
perf: run gunicorn with threaded workers

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -22,9 +22,4 @@ RUN chmod 0644 /etc/cron.d/cleanup-cron && crontab /etc/cron.d/cleanup-cron
 
 EXPOSE 5000
 
-# Threaded workers, not the default single sync worker: every request here is a
-# slow outbound scrape that is almost entirely network wait, and the UI fans out
-# one request per word per resource. --timeout is raised from the default 30s
-# because gunicorn kills the whole worker on timeout, taking sibling requests
-# down with it.
 CMD bash -c "cron && gunicorn -b :5000 -w 2 -k gthread --threads 8 --timeout 120 api.api:app"

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -22,4 +22,9 @@ RUN chmod 0644 /etc/cron.d/cleanup-cron && crontab /etc/cron.d/cleanup-cron
 
 EXPOSE 5000
 
-CMD bash -c "cron && gunicorn -b :5000 api.api:app"
+# Threaded workers, not the default single sync worker: every request here is a
+# slow outbound scrape that is almost entirely network wait, and the UI fans out
+# one request per word per resource. --timeout is raised from the default 30s
+# because gunicorn kills the whole worker on timeout, taking sibling requests
+# down with it.
+CMD bash -c "cron && gunicorn -b :5000 -w 2 -k gthread --threads 8 --timeout 120 api.api:app"


### PR DESCRIPTION
## Description
Runs the API on 2 gthread workers with 8 threads each, instead of gunicorn's default single sync worker.

The workload suits it: every scrape is an outbound HTTP call that's almost entirely network wait, and the UI issues one request per word per resource plus a burst of health checks on language select. Threaded workers let those overlap rather than queue, and threads beat processes here because the work is I/O-bound and t2.micro has 1 vCPU / 1GB.

Also sets `--timeout 120`, up from the default 30s. Gunicorn kills the whole worker on timeout, so a long scrape can take sibling requests with it.

## Testing

Ran gunicorn locally with these exact flags: boots clean on the gthread worker class, both workers up, `/api/supported-languages` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)