### PR TITLE
fix: stop an unreachable resource from hanging the health check

### DIFF
--- a/src/components/forms/resource-form/ResourceForm.tsx
+++ b/src/components/forms/resource-form/ResourceForm.tsx
@@ -17,6 +17,8 @@ import {
   TRANSITION,
 } from "../../../constants/animations";
 
+const HEALTH_CHECK_TIMEOUT_MS = 10000;
+
 export default function ResourceForm() {
   const [currentStep, setCurrentStep] = useState<
     "languages" | "words" | "resources" | ""
@@ -46,10 +48,18 @@ export default function ResourceForm() {
           const healthPromises: Promise<boolean>[] = data.resources.map(
             (resource: LanguageResource) => {
               return new Promise((res) => {
-                fetch(resource.healthRoute).then((response) => {
-                  resource["isHealthy"] = response.ok;
-                  res(true);
-                });
+                fetch(resource.healthRoute, {
+                  signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+                })
+                  .then((response) => {
+                    resource["isHealthy"] = response.ok;
+                  })
+                  .catch(() => {
+                    resource["isHealthy"] = false;
+                  })
+                  .finally(() => {
+                    res(true);
+                  });
               });
             }
           );

--- a/src/components/forms/resource-form/__tests__/ResourceForm.spec.tsx
+++ b/src/components/forms/resource-form/__tests__/ResourceForm.spec.tsx
@@ -18,8 +18,6 @@ import {
 const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
 
-// A fresh store per test so language resources from one test don't leak into
-// the next.
 function createTestStore() {
   return configureStore({
     reducer: { root: rootReducer, resourceForm: resourceFormReducer },
@@ -73,7 +71,7 @@ describe("ResourceForm.tsx", () => {
   });
 
   describe("When every resource's health check succeeds", () => {
-    it("Then marks all of the resources healthy", async () => {
+    it("Then marks all resources as healthy", async () => {
       // Arrange
       mockFetchRoutes({
         [wordReferenceResource.healthRoute]: healthy,
@@ -97,7 +95,7 @@ describe("ResourceForm.tsx", () => {
   });
 
   describe("When a resource's health check returns an error status", () => {
-    it("Then marks that resource unhealthy", async () => {
+    it("Then marks that resource as unhealthy", async () => {
       // Arrange
       mockFetchRoutes({
         [wordReferenceResource.healthRoute]: unhealthy,
@@ -120,8 +118,8 @@ describe("ResourceForm.tsx", () => {
     });
   });
 
-  describe("When a resource's health check request fails outright", () => {
-    it("Then still resolves and marks that resource unhealthy", async () => {
+  describe("When a resource's health check request fails", () => {
+    it("Then still resolves and marks that resource as unhealthy", async () => {
       // Arrange
       mockFetchRoutes({
         [wordReferenceResource.healthRoute]: unreachable,
@@ -144,7 +142,7 @@ describe("ResourceForm.tsx", () => {
     });
   });
 
-  describe("When every resource's health check request fails outright", () => {
+  describe("When every resource's health check request fails", () => {
     it("Then still dispatches the resources rather than hanging", async () => {
       // Arrange
       mockFetchRoutes({

--- a/src/components/forms/resource-form/__tests__/ResourceForm.spec.tsx
+++ b/src/components/forms/resource-form/__tests__/ResourceForm.spec.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import createFetchMock from "vitest-fetch-mock";
+import ResourceForm from "../ResourceForm";
+import rootReducer from "../../../../store/rootSlice";
+import resourceFormReducer, {
+  setTargetLanguage,
+} from "../../../../store/resourceFormSlice";
+import {
+  michaelisResource,
+  resourcesResponse,
+  supportedLanguagesResponse,
+  wordReferenceResource,
+} from "./mocks";
+
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+// A fresh store per test so language resources from one test don't leak into
+// the next.
+function createTestStore() {
+  return configureStore({
+    reducer: { root: rootReducer, resourceForm: resourceFormReducer },
+  });
+}
+
+/**
+ * Mocks the two requests the form makes on mount, plus each resource's health
+ * route. `healthResponders` maps a resource's healthRoute to a function that
+ * returns its response, or rejects to simulate an unreachable server.
+ */
+function mockFetchRoutes(healthResponders: {
+  [healthRoute: string]: () => Promise<{ body: string; status: number }>;
+}) {
+  fetchMocker.mockResponse((req: Request) => {
+    const url = decodeURIComponent(req.url);
+    if (url.includes("api/supported-languages")) {
+      return Promise.resolve(JSON.stringify(supportedLanguagesResponse));
+    }
+    if (url.includes("api/resources/")) {
+      return Promise.resolve(JSON.stringify(resourcesResponse));
+    }
+    for (const [healthRoute, responder] of Object.entries(healthResponders)) {
+      if (url.includes(decodeURIComponent(healthRoute))) {
+        return responder();
+      }
+    }
+    return Promise.resolve("");
+  });
+}
+
+const healthy = () => Promise.resolve({ body: "", status: 200 });
+const unhealthy = () => Promise.resolve({ body: "", status: 500 });
+const unreachable = () => Promise.reject(new Error("Failed to fetch"));
+
+function renderForm(store: ReturnType<typeof createTestStore>) {
+  // targetLanguage set with no nativeLanguage keeps the form on the
+  // "languages" step, which is what triggers the health checks.
+  store.dispatch(setTargetLanguage("português"));
+  render(
+    <Provider store={store}>
+      <ResourceForm />
+    </Provider>
+  );
+}
+
+describe("ResourceForm.tsx", () => {
+  beforeEach(() => {
+    fetchMocker.resetMocks();
+    window.scrollTo = vi.fn();
+  });
+
+  describe("When every resource's health check succeeds", () => {
+    it("Then marks all of the resources healthy", async () => {
+      // Arrange
+      mockFetchRoutes({
+        [wordReferenceResource.healthRoute]: healthy,
+        [michaelisResource.healthRoute]: healthy,
+      });
+      const store = createTestStore();
+      // Act
+      renderForm(store);
+      // Assert
+      await waitFor(() => {
+        expect(store.getState().resourceForm.languageResources.length).toEqual(
+          2
+        );
+      });
+      const resources = store.getState().resourceForm.languageResources;
+      expect(resources.map((resource) => resource.isHealthy)).toEqual([
+        true,
+        true,
+      ]);
+    });
+  });
+
+  describe("When a resource's health check returns an error status", () => {
+    it("Then marks that resource unhealthy", async () => {
+      // Arrange
+      mockFetchRoutes({
+        [wordReferenceResource.healthRoute]: unhealthy,
+        [michaelisResource.healthRoute]: healthy,
+      });
+      const store = createTestStore();
+      // Act
+      renderForm(store);
+      // Assert
+      await waitFor(() => {
+        expect(store.getState().resourceForm.languageResources.length).toEqual(
+          2
+        );
+      });
+      const resources = store.getState().resourceForm.languageResources;
+      expect(resources.map((resource) => resource.isHealthy)).toEqual([
+        false,
+        true,
+      ]);
+    });
+  });
+
+  describe("When a resource's health check request fails outright", () => {
+    it("Then still resolves and marks that resource unhealthy", async () => {
+      // Arrange
+      mockFetchRoutes({
+        [wordReferenceResource.healthRoute]: unreachable,
+        [michaelisResource.healthRoute]: healthy,
+      });
+      const store = createTestStore();
+      // Act
+      renderForm(store);
+      // Assert
+      await waitFor(() => {
+        expect(store.getState().resourceForm.languageResources.length).toEqual(
+          2
+        );
+      });
+      const resources = store.getState().resourceForm.languageResources;
+      expect(resources.map((resource) => resource.isHealthy)).toEqual([
+        false,
+        true,
+      ]);
+    });
+  });
+
+  describe("When every resource's health check request fails outright", () => {
+    it("Then still dispatches the resources rather than hanging", async () => {
+      // Arrange
+      mockFetchRoutes({
+        [wordReferenceResource.healthRoute]: unreachable,
+        [michaelisResource.healthRoute]: unreachable,
+      });
+      const store = createTestStore();
+      // Act
+      renderForm(store);
+      // Assert
+      await waitFor(() => {
+        expect(store.getState().resourceForm.languageResources.length).toEqual(
+          2
+        );
+      });
+      const resources = store.getState().resourceForm.languageResources;
+      expect(resources.map((resource) => resource.isHealthy)).toEqual([
+        false,
+        false,
+      ]);
+    });
+  });
+
+  describe("When the health checks are requested", () => {
+    it("Then each one is given a timeout signal", async () => {
+      // Arrange
+      mockFetchRoutes({
+        [wordReferenceResource.healthRoute]: healthy,
+        [michaelisResource.healthRoute]: healthy,
+      });
+      const store = createTestStore();
+      // Act
+      renderForm(store);
+      // Assert
+      await waitFor(() => {
+        expect(store.getState().resourceForm.languageResources.length).toEqual(
+          2
+        );
+      });
+      const healthRoutes = [
+        wordReferenceResource.healthRoute,
+        michaelisResource.healthRoute,
+      ];
+      const healthCalls = fetchMocker.mock.calls.filter(([input]) =>
+        healthRoutes.includes(input as string)
+      );
+      expect(healthCalls.length).toEqual(2);
+      healthCalls.forEach(([, init]) => {
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+      });
+    });
+  });
+});

--- a/src/components/forms/resource-form/__tests__/mocks.ts
+++ b/src/components/forms/resource-form/__tests__/mocks.ts
@@ -1,0 +1,27 @@
+import { LanguageResource } from "../../../../types/types";
+
+export const wordReferenceResource: LanguageResource = {
+  args: ["targetLang", "nativeLang", "word"],
+  name: "Word Reference",
+  outputs: ["word", "pos", "definition", "translations"],
+  route: "api/wr/",
+  healthRoute: "api/wr/français/english/vérifier",
+  supportedLanguages: ["english", "español", "português", "français"],
+} as LanguageResource;
+
+export const michaelisResource: LanguageResource = {
+  args: ["word"],
+  name: "Michaelis BR",
+  outputs: ["word", "pos", "definition", "targetExampleSentences"],
+  route: "api/michaelis-br/",
+  healthRoute: "api/michaelis-br/abacaxi",
+  supportedLanguages: ["português"],
+} as LanguageResource;
+
+export const supportedLanguagesResponse = {
+  languages: ["english", "português"],
+};
+
+export const resourcesResponse = {
+  resources: [wordReferenceResource, michaelisResource],
+};

--- a/src/components/forms/utils/__tests__/getFlashcardData.spec.ts
+++ b/src/components/forms/utils/__tests__/getFlashcardData.spec.ts
@@ -69,6 +69,22 @@ describe("getFlashcardData.ts", () => {
         });
       });
 
+      describe("When the word is scraped", () => {
+        it("Then the request is given a timeout signal", async () => {
+          // Arrange
+          const inputFields: InputFields = abacaxiWordReferenceInput;
+          fetchMocker.mockResponse(
+            JSON.stringify(abacaxiWordReferenceResponse)
+          );
+          // Act
+          await getFlashcardData(inputFields);
+          // Assert
+          expect(fetchMocker.mock.calls.length).toEqual(1);
+          const [, init] = fetchMocker.mock.calls[0];
+          expect(init?.signal).toBeInstanceOf(AbortSignal);
+        });
+      });
+
       describe("When the word is not scraped successfully", () => {
         it("Then returns an empty list for scraped data", async () => {
           // Arrange

--- a/src/components/forms/utils/getFlashcardData.ts
+++ b/src/components/forms/utils/getFlashcardData.ts
@@ -6,6 +6,8 @@ import {
   ScrapedResponse,
 } from "../../../types/types";
 
+const SCRAPE_TIMEOUT_MS = 25000;
+
 export function getFlashcardData(
   inputFields: InputFields,
   onWordDone?: () => void
@@ -33,7 +35,7 @@ export function getFlashcardData(
             const url =
               resource.route +
               resource.args.map((argName) => args[argName]).join("/");
-            fetch(url)
+            fetch(url, { signal: AbortSignal.timeout(SCRAPE_TIMEOUT_MS) })
               .then((res) => {
                 if (!res.ok) {
                   throw new Error(`HTTP error! Status: ${res.status}`);


### PR DESCRIPTION
Closes #10

## Summary

Fixes a hang in the resource health check. When a resource's `healthRoute` fetch **rejected** — server down, DNS failure, connection refused — the surrounding promise never settled, so `Promise.all(healthPromises)` never resolved, `setLanguageResources` was never dispatched, and the resource list never rendered. The health dots spun indefinitely with no way forward.

The scrapers themselves already have a 20s request timeout via `http_client.DEFAULT_TIMEOUT`, so this is purely about the client handling a request that fails rather than returns.

## Changes

**`ResourceForm.tsx`** — the health-check promise now resolves in `.finally()` instead of only inside `.then()`, and marks the resource unhealthy in `.catch()`. A resource that's unreachable shows a red dot instead of stalling the whole step. Health checks also get a 10s `AbortSignal.timeout`.

**`getFlashcardData.ts`** — scrape requests get a 25s `AbortSignal.timeout`. This path already degraded gracefully via its existing `.catch`, so this only bounds tail latency rather than fixing a hang.

## Notes

No backend changes. Adding `try`/`except` around the scrapers' `fetch` calls was considered and dropped: the frontend treats any non-`ok` response identically, so converting Flask's 500 into a 504 produced no observable difference — and it would have swallowed the traceback Flask currently logs on an unhandled exception, which is the only diagnostic signal the API emits today.

The 10s health-check deadline is shorter than the server's own 20s scrape timeout, so a genuinely slow-but-working site can show as unhealthy. That tradeoff favors a responsive UI over strict accuracy; worth revisiting if it produces false negatives in practice.

## Tests

New `ResourceForm.spec.tsx` covers the health-check paths, following the existing `getFlashcardData.spec.ts` pattern (`vitest-fetch-mock`, `describe`/`it` "When/Then", mocks in a sibling `mocks.ts`). It uses a fresh store per test so resources don't leak between cases:

- a check returning an error status marks that resource unhealthy
- a check that **rejects** marks it unhealthy and still dispatches the list
- all checks rejecting still dispatches rather than leaving `Promise.all` pending
- health checks are given an abort signal

Verified as real regression coverage — against `main`'s version of the component, the two rejection tests fail by timing out (`expected +0 to deeply equal 2`) and the signal test fails with `expected undefined to be an instance of AbortSignal`. The two success-path cases pass on both and are there as characterization.

`getFlashcardData.spec.ts` gains one case asserting the scrape request carries an abort signal; that file's existing rejection test already covered the error-recording path.

## Test plan

- `npx vitest run` — 16 passed (was 10).
- `npm run lint` — clean.
- `npx tsc --noEmit` — clean.
- `npm run test-api` — 78 passed (unchanged from `main`).


